### PR TITLE
Implement Sprint 1 tax configuration and calculations

### DIFF
--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -31,26 +31,38 @@ deliver user value in incremental, testable slices.
    - Provide deployment guides, observability hooks, and maintenance playbooks.
    - Facilitate contributor onboarding with comprehensive documentation.
 
-## Sprint 0 (Current)
+## Sprint 0 (Completed)
+
+**Highlights**
+- Repository scaffolding for the Flask back-end, static front-end, and shared
+  configuration assets.
+- Development tooling (pytest, linting, VS Code configuration) verified via
+  placeholder tests.
+- Delivery roadmap documented to onboard contributors.
+
+## Sprint 1 (Current)
 
 **Objectives**
-- Establish repository structure for front-end, back-end, and configuration
-  assets.
-- Configure development tooling (Python, Flask, pytest, linting) for use in
-  Visual Studio Code.
-- Document the iterative delivery plan and placeholder TODOs for upcoming work.
+- Provide validated, structured configuration for 2024 tax rules.
+- Deliver the first slice of the tax engine covering employment and freelance
+  income, including statutory credits and the trade fee.
+- Introduce localization plumbing to support bilingual responses.
 
 **Deliverables**
-- Source tree scaffold with TODO markers for pending implementation items.
-- Initial automated test placeholders to verify wiring and enable CI pipelines.
-- Documentation updates (this plan, README references) enabling new
-  contributors to understand the roadmap.
+- Dataclass-backed configuration loader with schema validation and caching.
+- 2024 YAML configuration featuring progressive brackets, tax credits, and
+  trade-fee parameters.
+- Calculation service producing bilingual summaries for employment and
+  freelance scenarios with unit test coverage.
+- Localization catalogue supporting English and Greek labels for backend
+  responses.
 
-**Next Steps (Preview of Sprint 1)**
-- Flesh out year-configuration schema and validation logic.
-- Implement foundational tax calculation routines for employment and freelance
-  income, backed by unit tests.
-- Begin localization groundwork (resource files, language toggle strategy).
+**Next Steps (Preview of Sprint 2)**
+- Extend the calculation engine to cover rental, investment, and pension
+  categories with aggregation logic.
+- Expand localization resources and begin wiring front-end language toggles.
+- Add payload validation errors suitable for API responses and document the
+  request/response contract.
 
-> _This plan will be updated at the conclusion of each sprint to reflect
-> completed work and upcoming milestones._
+> _This plan is updated at the end of each sprint to capture accomplishments_
+> _and upcoming milestones._

--- a/src/greektax/backend/app/localization/__init__.py
+++ b/src/greektax/backend/app/localization/__init__.py
@@ -1,0 +1,5 @@
+"""Localization utilities for GreekTax backend components."""
+
+from .catalog import Translator, get_translator, normalise_locale
+
+__all__ = ["Translator", "get_translator", "normalise_locale"]

--- a/src/greektax/backend/app/localization/catalog.py
+++ b/src/greektax/backend/app/localization/catalog.py
@@ -1,0 +1,64 @@
+"""Lightweight translation catalogue for backend responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+_BASE_LOCALE = "en"
+
+_MESSAGES: Dict[str, Dict[str, str]] = {
+    "en": {
+        "details.employment": "Employment income",
+        "details.freelance": "Freelance income",
+        "details.trade_fee": "Business activity fee",
+        "summary.income_total": "Total income",
+        "summary.tax_total": "Total taxes",
+        "summary.net_income": "Net income",
+    },
+    "el": {
+        "details.employment": "Εισόδημα μισθωτών",
+        "details.freelance": "Εισόδημα ελευθέρων επαγγελματιών",
+        "details.trade_fee": "Τέλος επιτηδεύματος",
+        "summary.income_total": "Συνολικό εισόδημα",
+        "summary.tax_total": "Συνολικοί φόροι",
+        "summary.net_income": "Καθαρό εισόδημα",
+    },
+}
+
+
+@dataclass(frozen=True)
+class Translator:
+    """Callable helper for retrieving localized strings."""
+
+    locale: str
+    _messages: Dict[str, str]
+    _fallback: Dict[str, str]
+
+    def __call__(self, key: str) -> str:
+        return self._messages.get(key) or self._fallback.get(key, key)
+
+
+def normalise_locale(locale: str | None) -> str:
+    """Normalise requested locale to a supported catalogue key."""
+
+    if not locale:
+        return _BASE_LOCALE
+
+    normalized = locale.lower().split("-")[0]
+    return normalized if normalized in _MESSAGES else _BASE_LOCALE
+
+
+def get_translator(locale: str | None = None) -> Translator:
+    """Return a translator instance for the requested locale."""
+
+    normalized = normalise_locale(locale)
+    messages = _MESSAGES.get(normalized, {})
+    fallback = _MESSAGES[_BASE_LOCALE]
+    if normalized == _BASE_LOCALE:
+        return Translator(locale=normalized, _messages=messages, _fallback=messages)
+
+    return Translator(locale=normalized, _messages=messages, _fallback=fallback)
+
+
+__all__ = ["Translator", "get_translator", "normalise_locale"]

--- a/src/greektax/backend/app/services/calculation_service.py
+++ b/src/greektax/backend/app/services/calculation_service.py
@@ -1,34 +1,276 @@
-"""Business logic for tax calculations.
+"""Business logic for tax calculations."""
 
-TODO: Implement modular calculation pipelines that combine income categories,
-deductions, and year-specific rules defined in ``greektax.backend.config``.
-"""
+from __future__ import annotations
 
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+from greektax.backend.app.localization import Translator, get_translator
+from greektax.backend.config.year_config import (
+    EmploymentConfig,
+    FreelanceConfig,
+    TaxBracket,
+    YearConfiguration,
+    load_year_configuration,
+)
+
+
+@dataclass(frozen=True)
+class _NormalisedPayload:
+    """Validates and stores user input in a predictable structure."""
+
+    year: int
+    locale: str
+    children: int
+    employment_income: float
+    freelance_profit: float
+    freelance_contributions: float
+    include_trade_fee: bool
+
+    @property
+    def freelance_taxable_income(self) -> float:
+        taxable = self.freelance_profit - self.freelance_contributions
+        return taxable if taxable > 0 else 0.0
+
+    @property
+    def has_employment_income(self) -> bool:
+        return self.employment_income > 0
+
+    @property
+    def has_freelance_activity(self) -> bool:
+        return (
+            self.freelance_profit > 0
+            or self.freelance_contributions > 0
+            or self.freelance_taxable_income > 0
+        )
+
+
+def _to_float(value: Any, field_name: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Field '{field_name}' must be numeric") from exc
+
+    if number < 0:
+        raise ValueError(f"Field '{field_name}' cannot be negative")
+
+    return number
+
+
+def _to_int(value: Any, field_name: str) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Field '{field_name}' must be an integer") from exc
+
+    if number < 0:
+        raise ValueError(f"Field '{field_name}' cannot be negative")
+
+    return number
+
+
+def _to_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        if normalised in {"true", "1", "yes", "y"}:
+            return True
+        if normalised in {"false", "0", "no", "n"}:
+            return False
+
+    raise ValueError("Boolean fields accept true/false values only")
+
+
+def _extract_section(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    section = payload.get(key, {})
+    if section is None:
+        return {}
+    if not isinstance(section, Mapping):
+        raise ValueError(f"Section '{key}' must be a mapping")
+    return section
+
+
+def _normalise_payload(payload: Mapping[str, Any]) -> _NormalisedPayload:
+    if not isinstance(payload, Mapping):
+        raise ValueError("Payload must be a mapping")
+
+    if "year" not in payload:
+        raise ValueError("Payload must include a tax year")
+
+    year = _to_int(payload["year"], "year")
+    locale = str(payload.get("locale", "en"))
+
+    dependants_section = _extract_section(payload, "dependents")
+    children = _to_int(dependants_section.get("children", 0), "dependents.children")
+
+    employment_section = _extract_section(payload, "employment")
+    employment_income = _to_float(
+        employment_section.get("gross_income", 0.0), "employment.gross_income"
+    )
+
+    freelance_section = _extract_section(payload, "freelance")
+    profit_value: Optional[Any] = freelance_section.get("profit")
+    if profit_value is None:
+        revenue = _to_float(
+            freelance_section.get("gross_revenue", 0.0), "freelance.gross_revenue"
+        )
+        expenses = _to_float(
+            freelance_section.get("deductible_expenses", 0.0),
+            "freelance.deductible_expenses",
+        )
+        profit = revenue - expenses
+        profit = profit if profit > 0 else 0.0
+    else:
+        profit = _to_float(profit_value, "freelance.profit")
+
+    contributions = _to_float(
+        freelance_section.get("mandatory_contributions", 0.0),
+        "freelance.mandatory_contributions",
+    )
+
+    include_trade_fee = _to_bool(freelance_section.get("include_trade_fee"), True)
+
+    return _NormalisedPayload(
+        year=year,
+        locale=locale,
+        children=children,
+        employment_income=employment_income,
+        freelance_profit=profit,
+        freelance_contributions=contributions,
+        include_trade_fee=include_trade_fee,
+    )
+
+
+def _calculate_progressive_tax(amount: float, brackets: Sequence[TaxBracket]) -> float:
+    if amount <= 0:
+        return 0.0
+
+    total = 0.0
+    lower_bound = 0.0
+
+    for bracket in brackets:
+        upper = bracket.upper_bound
+        if upper is None or amount < upper:
+            total += (amount - lower_bound) * bracket.rate
+            break
+
+        total += (upper - lower_bound) * bracket.rate
+        lower_bound = upper
+
+    return total
+
+
+def _calculate_employment(
+    payload: _NormalisedPayload,
+    config: EmploymentConfig,
+    translator: Translator,
+) -> Optional[Dict[str, Any]]:
+    if not payload.has_employment_income:
+        return None
+
+    gross = payload.employment_income
+    taxable = gross
+    tax_before_credit = _calculate_progressive_tax(taxable, config.brackets)
+    credit = config.tax_credit.amount_for_children(payload.children)
+    tax_after_credit = tax_before_credit - credit
+    if tax_after_credit < 0:
+        tax_after_credit = 0.0
+
+    detail = {
+        "category": "employment",
+        "label": translator("details.employment"),
+        "gross_income": _round_currency(gross),
+        "taxable_income": _round_currency(taxable),
+        "tax_before_credits": _round_currency(tax_before_credit),
+        "credits": _round_currency(credit),
+        "tax": _round_currency(tax_after_credit),
+        "total_tax": _round_currency(tax_after_credit),
+        "net_income": _round_currency(gross - tax_after_credit),
+    }
+    return detail
+
+
+def _calculate_trade_fee(payload: _NormalisedPayload, config: FreelanceConfig) -> float:
+    if not payload.include_trade_fee:
+        return 0.0
+    if payload.freelance_taxable_income <= 0:
+        return 0.0
+    return config.trade_fee.standard_amount
+
+
+def _calculate_freelance(
+    payload: _NormalisedPayload,
+    config: FreelanceConfig,
+    translator: Translator,
+) -> Optional[Dict[str, Any]]:
+    if not payload.has_freelance_activity:
+        return None
+
+    gross = payload.freelance_profit
+    contributions = payload.freelance_contributions
+    taxable = payload.freelance_taxable_income
+    tax = _calculate_progressive_tax(taxable, config.brackets)
+    trade_fee = _calculate_trade_fee(payload, config)
+    total_tax = tax + trade_fee
+    net_income = gross - contributions - total_tax
+
+    detail = {
+        "category": "freelance",
+        "label": translator("details.freelance"),
+        "gross_income": _round_currency(gross),
+        "deductible_contributions": _round_currency(contributions),
+        "taxable_income": _round_currency(taxable),
+        "tax": _round_currency(tax),
+        "trade_fee": _round_currency(trade_fee),
+        "total_tax": _round_currency(total_tax),
+        "net_income": _round_currency(net_income),
+    }
+    if trade_fee:
+        detail["trade_fee_label"] = translator("details.trade_fee")
+    return detail
+
+
+def _round_currency(value: float) -> float:
+    return round(value, 2)
 
 
 def calculate_tax(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Compute tax summary for the provided payload.
+    """Compute tax summary for the provided payload."""
 
-    Args:
-        payload: Input dictionary containing user-provided financial data and
-            selected configuration metadata.
+    normalised = _normalise_payload(payload)
+    config: YearConfiguration = load_year_configuration(normalised.year)
+    translator = get_translator(normalised.locale)
 
-    Returns:
-        A dictionary containing structured calculation results ready for
-        serialization.
+    details: list[Dict[str, Any]] = []
+    employment_detail = _calculate_employment(normalised, config.employment, translator)
+    if employment_detail:
+        details.append(employment_detail)
 
-    TODO: Integrate validation, currency handling, bilingual messaging, and
-    progressive tax calculations per income type.
-    """
+    freelance_detail = _calculate_freelance(normalised, config.freelance, translator)
+    if freelance_detail:
+        details.append(freelance_detail)
 
-    # TODO: Replace placeholder logic with real calculation pipeline once the
-    # computation modules are implemented.
+    income_total = sum(item.get("gross_income", 0.0) for item in details)
+    tax_total = sum(item.get("total_tax", 0.0) for item in details)
+    net_income = sum(item.get("net_income", 0.0) for item in details)
+
     return {
         "summary": {
-            "income_total": 0.0,
-            "tax_total": 0.0,
-            "net_income": 0.0,
+            "income_total": _round_currency(income_total),
+            "tax_total": _round_currency(tax_total),
+            "net_income": _round_currency(net_income),
+            "labels": {
+                "income_total": translator("summary.income_total"),
+                "tax_total": translator("summary.tax_total"),
+                "net_income": translator("summary.net_income"),
+            },
         },
-        "details": [],
+        "details": details,
+        "meta": {
+            "year": normalised.year,
+            "locale": translator.locale,
+        },
     }

--- a/src/greektax/backend/config/data/2024.yaml
+++ b/src/greektax/backend/config/data/2024.yaml
@@ -1,7 +1,39 @@
-# TODO: Populate 2024 configuration with official tax brackets, credits, and
-# localized labels. Each section should align with the domain models defined in
-# ``greektax.backend.app.models`` once implemented.
+year: 2024
 meta:
-  version: 0
+  version: 1
   status: draft
-  notes: "Placeholder configuration for initial scaffolding"
+  notes: "Initial 2024 configuration with employment and freelance coverage"
+income:
+  employment:
+    tax_brackets:
+      - upper: 10000
+        rate: 0.09
+      - upper: 20000
+        rate: 0.22
+      - upper: 30000
+        rate: 0.28
+      - upper: 40000
+        rate: 0.36
+      - rate: 0.44
+    tax_credit:
+      amounts_by_children:
+        "0": 777
+        "1": 810
+        "2": 900
+        "3": 1120
+      incremental_amount_per_child: 220
+  freelance:
+    tax_brackets:
+      - upper: 10000
+        rate: 0.09
+      - upper: 20000
+        rate: 0.22
+      - upper: 30000
+        rate: 0.28
+      - upper: 40000
+        rate: 0.36
+      - rate: 0.44
+    trade_fee:
+      standard_amount: 650
+      reduced_amount: 325
+      newly_self_employed_reduction_years: 5

--- a/src/greektax/backend/config/year_config.py
+++ b/src/greektax/backend/config/year_config.py
@@ -1,36 +1,232 @@
 """Year-based configuration loader for Greek tax rules."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
 
 import yaml
 
 CONFIG_DIRECTORY = Path(__file__).resolve().parent / "data"
 
 
-@dataclass
+class ConfigurationError(ValueError):
+    """Raised when a configuration file fails validation."""
+
+
+@dataclass(frozen=True)
+class TaxBracket:
+    """Represents a single progressive tax bracket."""
+
+    upper_bound: Optional[float]
+    rate: float
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive programming
+        if self.rate < 0:
+            raise ConfigurationError("Tax rates must be non-negative")
+        if self.upper_bound is not None and self.upper_bound <= 0:
+            raise ConfigurationError("Upper bounds must be positive values")
+
+
+@dataclass(frozen=True)
+class EmploymentTaxCredit:
+    """Year-specific reduction applied to employment income tax."""
+
+    amounts_by_children: Dict[int, float]
+    incremental_amount_per_child: float
+
+    def amount_for_children(self, dependants: int) -> float:
+        """Return the tax credit amount for the provided dependant count."""
+
+        if dependants < 0:
+            return 0.0
+
+        if dependants in self.amounts_by_children:
+            return self.amounts_by_children[dependants]
+
+        if not self.amounts_by_children:
+            return 0.0
+
+        max_key = max(self.amounts_by_children)
+        base_amount = self.amounts_by_children[max_key]
+        if dependants <= max_key:
+            return base_amount
+
+        extra_children = dependants - max_key
+        return base_amount + extra_children * self.incremental_amount_per_child
+
+
+@dataclass(frozen=True)
+class EmploymentConfig:
+    """Configuration for salaried/pension income."""
+
+    brackets: Sequence[TaxBracket]
+    tax_credit: EmploymentTaxCredit
+
+
+@dataclass(frozen=True)
+class TradeFeeConfig:
+    """Settings for the business activity fee (τέλος επιτηδεύματος)."""
+
+    standard_amount: float
+    reduced_amount: Optional[float] = None
+    newly_self_employed_reduction_years: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class FreelanceConfig:
+    """Configuration for freelance/business income."""
+
+    brackets: Sequence[TaxBracket]
+    trade_fee: TradeFeeConfig
+
+
+@dataclass(frozen=True)
 class YearConfiguration:
     """Structured representation of a tax year configuration."""
 
     year: int
-    metadata: Dict[str, Any]
+    meta: Dict[str, Any]
+    employment: EmploymentConfig
+    freelance: FreelanceConfig
 
-    # TODO: Expand with strongly typed attributes (e.g., brackets, deductions,
-    # localized strings) for easier IDE discoverability.
+
+def _parse_tax_brackets(brackets: Iterable[Mapping[str, Any]]) -> Sequence[TaxBracket]:
+    parsed: list[TaxBracket] = []
+    last_upper: Optional[float] = None
+
+    for bracket in brackets:
+        if "rate" not in bracket:
+            raise ConfigurationError("Each tax bracket must define a 'rate'")
+
+        rate = float(bracket["rate"])
+        upper = bracket.get("upper")
+        upper_bound = float(upper) if upper is not None else None
+
+        tax_bracket = TaxBracket(upper_bound=upper_bound, rate=rate)
+        if last_upper is not None and tax_bracket.upper_bound is not None:
+            if tax_bracket.upper_bound <= last_upper:
+                raise ConfigurationError("Tax brackets must be in ascending order")
+
+        parsed.append(tax_bracket)
+        last_upper = tax_bracket.upper_bound or last_upper
+
+    if not parsed:
+        raise ConfigurationError("At least one tax bracket must be defined")
+
+    if parsed[-1].upper_bound is not None:
+        raise ConfigurationError("Final tax bracket must have an open upper bound")
+
+    return parsed
 
 
+def _parse_employment_config(raw: Mapping[str, Any]) -> EmploymentConfig:
+    brackets_raw = raw.get("tax_brackets")
+    if not isinstance(brackets_raw, Iterable):
+        raise ConfigurationError("Employment configuration must include 'tax_brackets'")
+
+    credit_raw = raw.get("tax_credit")
+    if not isinstance(credit_raw, Mapping):
+        raise ConfigurationError("Employment configuration must include 'tax_credit'")
+
+    amounts_raw = credit_raw.get("amounts_by_children")
+    if not isinstance(amounts_raw, MutableMapping):
+        raise ConfigurationError("'amounts_by_children' must be a mapping")
+
+    amounts: Dict[int, float] = {}
+    for key, value in amounts_raw.items():
+        child_count = int(key)
+        amounts[child_count] = float(value)
+
+    incremental = float(credit_raw.get("incremental_amount_per_child", 0.0))
+
+    return EmploymentConfig(
+        brackets=_parse_tax_brackets(brackets_raw),
+        tax_credit=EmploymentTaxCredit(
+            amounts_by_children=amounts,
+            incremental_amount_per_child=incremental,
+        ),
+    )
+
+
+def _parse_trade_fee(raw: Mapping[str, Any]) -> TradeFeeConfig:
+    if "standard_amount" not in raw:
+        raise ConfigurationError("Trade fee configuration requires 'standard_amount'")
+
+    standard = float(raw["standard_amount"])
+    reduced = raw.get("reduced_amount")
+    reduction_years = raw.get("newly_self_employed_reduction_years")
+
+    return TradeFeeConfig(
+        standard_amount=standard,
+        reduced_amount=float(reduced) if reduced is not None else None,
+        newly_self_employed_reduction_years=
+        int(reduction_years) if reduction_years is not None else None,
+    )
+
+
+def _parse_freelance_config(raw: Mapping[str, Any]) -> FreelanceConfig:
+    brackets_raw = raw.get("tax_brackets")
+    if not isinstance(brackets_raw, Iterable):
+        raise ConfigurationError("Freelance configuration must include 'tax_brackets'")
+
+    trade_fee_raw = raw.get("trade_fee")
+    if not isinstance(trade_fee_raw, Mapping):
+        raise ConfigurationError("Freelance configuration must include 'trade_fee'")
+
+    return FreelanceConfig(
+        brackets=_parse_tax_brackets(brackets_raw),
+        trade_fee=_parse_trade_fee(trade_fee_raw),
+    )
+
+
+def _parse_year_configuration(year: int, raw: Mapping[str, Any]) -> YearConfiguration:
+    income_section = raw.get("income")
+    if not isinstance(income_section, Mapping):
+        raise ConfigurationError("Configuration must include an 'income' section")
+
+    employment_raw = income_section.get("employment")
+    if not isinstance(employment_raw, Mapping):
+        raise ConfigurationError("Income configuration requires an 'employment' section")
+
+    freelance_raw = income_section.get("freelance")
+    if not isinstance(freelance_raw, Mapping):
+        raise ConfigurationError("Income configuration requires a 'freelance' section")
+
+    meta = raw.get("meta")
+    if meta is None:
+        meta = {}
+    elif not isinstance(meta, Mapping):
+        raise ConfigurationError("'meta' section must be a mapping if provided")
+
+    config_year = raw.get("year")
+    if config_year is not None and int(config_year) != year:
+        raise ConfigurationError(
+            f"Configuration year mismatch: expected {year}, found {config_year}"
+        )
+
+    return YearConfiguration(
+        year=year,
+        meta=dict(meta),
+        employment=_parse_employment_config(employment_raw),
+        freelance=_parse_freelance_config(freelance_raw),
+    )
+
+
+@lru_cache(maxsize=8)
 def load_year_configuration(year: int) -> YearConfiguration:
-    """Load configuration for the specified tax year from disk.
+    """Load configuration for the specified tax year from disk."""
 
-    TODO: Implement caching and validation of configuration schemas.
-    """
     config_file = CONFIG_DIRECTORY / f"{year}.yaml"
     if not config_file.exists():
         raise FileNotFoundError(f"Configuration for year {year} not found")
 
-    # TODO: Validate against schema before constructing the dataclass.
     with config_file.open("r", encoding="utf-8") as handle:
-        raw_config = yaml.safe_load(handle)
+        raw_config = yaml.safe_load(handle) or {}
 
-    return YearConfiguration(year=year, metadata=raw_config)
+    if not isinstance(raw_config, Mapping):
+        raise ConfigurationError("Configuration file must define a mapping at the top level")
+
+    return _parse_year_configuration(year, raw_config)

--- a/tests/unit/test_calculation_service.py
+++ b/tests/unit/test_calculation_service.py
@@ -1,18 +1,94 @@
-"""Unit tests for the calculation service.
+"""Unit tests for the calculation service."""
 
-TODO: Flesh out comprehensive test coverage for each income type, deductions,
-credits, and localization behavior.
-"""
+from __future__ import annotations
+
+import pytest
 
 from greektax.backend.app.services.calculation_service import calculate_tax
 
 
-def test_calculate_tax_placeholder():
-    """Placeholder test ensuring scaffolded response structure."""
-    result = calculate_tax({})
+def test_calculate_tax_defaults_to_zero_summary() -> None:
+    """An empty payload (besides year) should produce zeroed totals."""
 
-    assert "summary" in result
-    assert "details" in result
+    result = calculate_tax({"year": 2024})
+
     assert result["summary"]["income_total"] == 0.0
     assert result["summary"]["tax_total"] == 0.0
     assert result["summary"]["net_income"] == 0.0
+    assert result["details"] == []
+    assert result["meta"] == {"year": 2024, "locale": "en"}
+
+
+def test_calculate_tax_employment_only() -> None:
+    """Employment income uses progressive rates and tax credit."""
+
+    payload = {
+        "year": 2024,
+        "locale": "en",
+        "dependents": {"children": 1},
+        "employment": {"gross_income": 30_000},
+    }
+
+    result = calculate_tax(payload)
+
+    summary = result["summary"]
+    assert summary["income_total"] == pytest.approx(30_000.0)
+    assert summary["tax_total"] == pytest.approx(5_090.0)
+    assert summary["net_income"] == pytest.approx(24_910.0)
+
+    assert len(result["details"]) == 1
+    employment_detail = result["details"][0]
+    assert employment_detail["category"] == "employment"
+    assert employment_detail["gross_income"] == pytest.approx(30_000.0)
+    assert employment_detail["tax_before_credits"] == pytest.approx(5_900.0)
+    assert employment_detail["credits"] == pytest.approx(810.0)
+    assert employment_detail["total_tax"] == pytest.approx(5_090.0)
+
+
+def test_calculate_tax_with_freelance_income() -> None:
+    """Freelance profit combines progressive tax and trade fee."""
+
+    payload = {
+        "year": 2024,
+        "locale": "en",
+        "dependents": {"children": 0},
+        "employment": {"gross_income": 20_000},
+        "freelance": {
+            "gross_revenue": 18_000,
+            "deductible_expenses": 4_000,
+            "mandatory_contributions": 3_000,
+        },
+    }
+
+    result = calculate_tax(payload)
+
+    assert result["summary"]["income_total"] == pytest.approx(34_000.0)
+    assert result["summary"]["tax_total"] == pytest.approx(4_093.0)
+    assert result["summary"]["net_income"] == pytest.approx(26_907.0)
+
+    assert len(result["details"]) == 2
+    employment_detail = next(
+        detail for detail in result["details"] if detail["category"] == "employment"
+    )
+    freelance_detail = next(
+        detail for detail in result["details"] if detail["category"] == "freelance"
+    )
+
+    assert employment_detail["total_tax"] == pytest.approx(2_323.0)
+    assert freelance_detail["taxable_income"] == pytest.approx(11_000.0)
+    assert freelance_detail["tax"] == pytest.approx(1_120.0)
+    assert freelance_detail["trade_fee"] == pytest.approx(650.0)
+    assert freelance_detail["total_tax"] == pytest.approx(1_770.0)
+    assert freelance_detail["net_income"] == pytest.approx(9_230.0)
+
+
+def test_calculate_tax_respects_locale_toggle() -> None:
+    """Locale toggle switches translation catalogue."""
+
+    payload = {"year": 2024, "locale": "el", "employment": {"gross_income": 10_000}}
+
+    result = calculate_tax(payload)
+
+    assert result["meta"]["locale"] == "el"
+    assert result["details"][0]["label"] == "Εισόδημα μισθωτών"
+    assert result["summary"]["labels"]["income_total"] == "Συνολικό εισόδημα"


### PR DESCRIPTION
## Summary
- add a typed year-configuration loader with validation and caching and seed the 2024 tax data
- build employment and freelance tax calculations with bilingual summaries
- introduce backend localization catalogue and expand unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd0659a7008324ad490075e91431c2