### PR TITLE
Implement calculation API endpoint and localisation preview

### DIFF
--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -11,8 +11,10 @@ POST /api/v1/calculations
 Content-Type: application/json
 ```
 
-> _The HTTP route will be implemented in a later sprint. The contract is stable
-> and already exercised by the calculation service tests._
+Successful requests return `200 OK` with the calculation payload described
+below. Validation issues produce a `400 Bad Request` response with a JSON body
+containing `error` and `message` fields. When invalid field values are
+detected, the API returns `{"error": "validation_error", "message": "..."}`.
 
 ## Request Body
 

--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -49,28 +49,39 @@ deliver user value in incremental, testable slices.
 - Localization plumbing with English and Greek catalogues plus comprehensive
   unit coverage.
 
-## Sprint 2 (Current)
+## Sprint 2 (Completed)
+
+**Highlights**
+- Calculation engine broadened to cover pension, rental, and investment income
+  categories with aggregated summaries.
+- Localization catalogue extended for the new income categories in both
+  supported languages.
+- API contract published with explicit validation guidance for future clients.
+
+## Sprint 3 (Current)
 
 **Objectives**
-- Broaden the calculation engine to cover pension, rental, and investment
-  income categories with aggregated summaries.
-- Expand the localization catalogue for the newly supported categories.
-- Publish an API contract and improve error messaging for validation failures.
+- Expose the calculation engine through a REST endpoint with structured error
+  handling.
+- Provide a language toggle on the front-end that propagates the selected
+  locale to the API.
+- Establish regression fixtures that exercise representative taxpayer profiles.
 
-**Deliverables**
-- Year configuration extended with pension, rental, and investment sections for
-  2024.
-- Calculation service enhancements producing bilingual breakdowns for all
-  categories alongside unit tests for new scenarios.
-- API contract documentation capturing request validation rules and
-  response structure.
+**Deliverables (to date)**
+- Flask blueprint serving `POST /api/v1/calculations` with localisation-aware
+  responses and JSON error envelopes.
+- Front-end preview controls that persist locale preference and request
+  translated summaries from the backend.
+- Regression scenario catalogue consumed by integration tests for ongoing
+  validation.
 
-**Next Steps (Preview of Sprint 3)**
-- Implement REST endpoints that expose the calculation service and return
-  structured validation errors.
-- Begin integrating the front-end language toggle with backend localization.
-- Introduce scenario fixtures that mirror representative taxpayer profiles for
-  regression testing.
+**Next Steps (Preview of Sprint 4)**
+- Add REST endpoints for configuration metadata (available years, investment
+  categories) to support dynamic UI elements.
+- Connect core form inputs on the front-end to the API and render the returned
+  breakdown.
+- Provide printable/exportable summaries and broaden scenario coverage to VAT
+  and ENFIA inputs.
 
 > _This plan is updated at the end of each sprint to capture accomplishments_
 > _and upcoming milestones._

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -7,4 +7,120 @@
  * - Handling form inputs and displaying calculation results
  */
 
-console.info("GreekTax frontend scaffold loaded");
+const API_ENDPOINT = "/api/v1/calculations";
+const STORAGE_KEY = "greektax.locale";
+
+const localeSelect = document.getElementById("locale-select");
+const previewButton = document.getElementById("preview-button");
+const previewStatus = document.getElementById("preview-status");
+const previewJson = document.getElementById("preview-json");
+
+const demoPayload = {
+  year: 2024,
+  dependents: { children: 1 },
+  employment: { gross_income: 24000 },
+  freelance: {
+    gross_revenue: 12000,
+    deductible_expenses: 2000,
+    mandatory_contributions: 2500,
+  },
+};
+
+function resolveStoredLocale(defaultLocale = "en") {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored || defaultLocale;
+  } catch (error) {
+    console.warn("Unable to access localStorage", error);
+    return defaultLocale;
+  }
+}
+
+function persistLocale(locale) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, locale);
+  } catch (error) {
+    console.warn("Unable to persist locale preference", error);
+  }
+}
+
+function applyLocale(locale) {
+  if (localeSelect) {
+    localeSelect.value = locale;
+  }
+  document.documentElement.lang = locale;
+  persistLocale(locale);
+}
+
+function setStatus(message, { isError = false, showJson = false } = {}) {
+  if (previewStatus) {
+    previewStatus.textContent = message;
+    previewStatus.setAttribute(
+      "data-status",
+      isError ? "error" : "info",
+    );
+  }
+
+  if (previewJson) {
+    previewJson.hidden = !showJson;
+  }
+}
+
+async function requestPreview(locale) {
+  const payload = { ...demoPayload, locale };
+  setStatus("Requesting preview from the API…");
+
+  try {
+    const response = await fetch(API_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Language": locale,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({}));
+      throw new Error(errorPayload.message || response.statusText);
+    }
+
+    const result = await response.json();
+    setStatus("Preview updated using backend localisation.", {
+      showJson: true,
+    });
+    if (previewJson) {
+      previewJson.textContent = JSON.stringify(result, null, 2);
+    }
+  } catch (error) {
+    console.error("Failed to load preview", error);
+    setStatus("Unable to fetch preview. Is the backend running?", {
+      isError: true,
+    });
+  }
+}
+
+function bootstrap() {
+  if (!localeSelect || !previewButton || !previewStatus || !previewJson) {
+    console.warn("Preview controls missing from DOM");
+    return;
+  }
+
+  const initialLocale = resolveStoredLocale();
+  applyLocale(initialLocale);
+
+  localeSelect.addEventListener("change", (event) => {
+    const target = event.target;
+    const locale = typeof target?.value === "string" ? target.value : "en";
+    applyLocale(locale);
+  });
+
+  previewButton.addEventListener("click", () => {
+    const locale = localeSelect.value || "en";
+    requestPreview(locale);
+  });
+
+  console.info("GreekTax localisation preview initialised");
+}
+
+document.addEventListener("DOMContentLoaded", bootstrap);

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -10,6 +10,13 @@ body {
   color: #222;
 }
 
+main {
+  max-width: 720px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
 header {
   text-align: center;
   margin-bottom: 2rem;
@@ -24,6 +31,59 @@ header {
   margin-top: 2rem;
   font-size: 0.9rem;
   color: #a33;
+}
+
+#language-preview {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.08);
+}
+
+#locale-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+#locale-select,
+#preview-button {
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+#preview-button {
+  background: #0d6efd;
+  border: none;
+  color: #fff;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+#preview-button:hover,
+#preview-button:focus {
+  background: #0b5ed7;
+}
+
+.preview-output {
+  margin-top: 1.5rem;
+  background: #f8f9fa;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  border: 1px solid #dee2e6;
+}
+
+#preview-status[data-status="error"] {
+  color: #b02a37;
+  font-weight: 600;
+}
+
+#preview-json {
+  max-height: 18rem;
+  overflow: auto;
+  margin: 0;
 }
 
 /* TODO: Implement responsive layout, bilingual typography adjustments, and

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -23,6 +23,26 @@
           storage. Please consult a professional accountant for formal filings.
         </p>
       </section>
+
+      <section id="language-preview" aria-labelledby="language-preview-title">
+        <h2 id="language-preview-title">Preview localisation</h2>
+        <p>
+          Choose your preferred language and request a sample calculation to see
+          the backend translations in action. The preview uses demo data only.
+        </p>
+        <form id="locale-form">
+          <label for="locale-select">Language</label>
+          <select id="locale-select" name="locale">
+            <option value="en">English</option>
+            <option value="el">Ελληνικά</option>
+          </select>
+          <button type="button" id="preview-button">Preview calculation</button>
+        </form>
+        <div class="preview-output" aria-live="polite">
+          <p id="preview-status">No preview requested yet.</p>
+          <pre id="preview-json" hidden></pre>
+        </div>
+      </section>
     </main>
 
     <script src="./assets/scripts/main.js" defer></script>

--- a/src/greektax/backend/app/__init__.py
+++ b/src/greektax/backend/app/__init__.py
@@ -1,26 +1,35 @@
 """Application factory for GreekTax backend services."""
 
-from flask import Flask
+from flask import Flask, jsonify
+from werkzeug.exceptions import BadRequest
+
+from .routes import register_routes
 
 
 def create_app() -> Flask:
-    """Create and configure the Flask application instance.
+    """Create and configure the Flask application instance."""
 
-    TODO: Register blueprints, configure localization, and initialize services
-    once the calculation engine and data layers are implemented.
-    """
     app = Flask(__name__)
 
-    # TODO: Load configuration dynamically based on environment variables and
-    # selected tax year once the configuration management module is completed.
+    register_routes(app)
 
     @app.route("/health", methods=["GET"])
     def health_check():
-        """Simple health check endpoint for infrastructure monitoring.
+        """Simple health check endpoint for infrastructure monitoring."""
 
-        TODO: Extend with dependency checks (e.g., configuration availability)
-        when ancillary services are introduced.
-        """
         return {"status": "ok"}
+
+    @app.errorhandler(BadRequest)
+    def handle_bad_request(error: BadRequest):
+        """Return consistent JSON responses for malformed payloads."""
+
+        message = error.description or "Invalid request"
+        return jsonify({"error": "bad_request", "message": message}), 400
+
+    @app.errorhandler(ValueError)
+    def handle_value_error(error: ValueError):
+        """Gracefully surface domain validation errors to clients."""
+
+        return jsonify({"error": "validation_error", "message": str(error)}), 400
 
     return app

--- a/src/greektax/backend/app/routes/__init__.py
+++ b/src/greektax/backend/app/routes/__init__.py
@@ -1,9 +1,11 @@
 """Blueprint registrations for application routes."""
 
-from flask import Blueprint
+from flask import Flask
 
-api_blueprint = Blueprint("api", __name__)
+from .calculations import blueprint as calculations_blueprint
 
-# TODO: Implement endpoints for tax calculation, configuration metadata, and
-# localization resources. They should delegate heavy-lifting to dedicated
-# service modules within ``greektax.backend.app.services``.
+
+def register_routes(app: Flask) -> None:
+    """Register all Flask blueprints with the provided application."""
+
+    app.register_blueprint(calculations_blueprint)

--- a/src/greektax/backend/app/routes/calculations.py
+++ b/src/greektax/backend/app/routes/calculations.py
@@ -1,0 +1,50 @@
+"""REST endpoints for tax calculations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import BadRequest
+
+from greektax.backend.app.localization import normalise_locale
+from greektax.backend.app.services.calculation_service import calculate_tax
+
+blueprint = Blueprint("calculations", __name__, url_prefix="/api/v1")
+
+
+def _resolve_locale(payload: Dict[str, Any]) -> None:
+    """Populate locale in payload using explicit or header-based hints."""
+
+    if "locale" in payload and payload["locale"]:
+        payload["locale"] = normalise_locale(str(payload["locale"]))
+        return
+
+    locale_param = request.args.get("locale")
+    if locale_param:
+        payload["locale"] = normalise_locale(locale_param)
+        return
+
+    accept_language = request.headers.get("Accept-Language")
+    if accept_language:
+        primary = accept_language.split(",")[0].strip()
+        if primary:
+            payload["locale"] = normalise_locale(primary)
+
+
+@blueprint.post("/calculations")
+def create_calculation() -> tuple[Any, int]:
+    """Create a tax calculation using the submitted JSON payload."""
+
+    data = request.get_json(silent=True)
+    if data is None:
+        raise BadRequest("Request body must be valid JSON")
+    if not isinstance(data, Mapping):
+        raise BadRequest("Request JSON must be an object")
+
+    payload: Dict[str, Any] = dict(data)
+    _resolve_locale(payload)
+
+    result = calculate_tax(payload)
+
+    return jsonify(result), 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Test configuration utilities."""
+"""Test configuration utilities and shared fixtures."""
 
 import sys
 from pathlib import Path
@@ -10,3 +10,25 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from greektax.backend.app import create_app
+
+
+@pytest.fixture()
+def app() -> Flask:
+    """Return a configured Flask application for integration tests."""
+
+    application = create_app()
+    application.config.update(TESTING=True)
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Provide a test client bound to the configured Flask app."""
+
+    return app.test_client()

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -1,0 +1,69 @@
+[
+  {
+    "name": "salary_freelance_combo",
+    "payload": {
+      "year": 2024,
+      "locale": "en",
+      "dependents": {"children": 0},
+      "employment": {"gross_income": 20000},
+      "freelance": {
+        "gross_revenue": 18000,
+        "deductible_expenses": 4000,
+        "mandatory_contributions": 3000
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 34000.0,
+        "tax_total": 4093.0,
+        "net_income": 26907.0
+      },
+      "details": {
+        "employment": {
+          "total_tax": 2323.0
+        },
+        "freelance": {
+          "taxable_income": 11000.0,
+          "total_tax": 1770.0
+        }
+      }
+    }
+  },
+  {
+    "name": "pension_rental_investment",
+    "payload": {
+      "year": 2024,
+      "dependents": {"children": 2},
+      "pension": {"gross_income": 18000},
+      "rental": {
+        "gross_income": 15000,
+        "deductible_expenses": 2000
+      },
+      "investment": {
+        "dividends": 1200,
+        "interest": 400,
+        "capital_gains": 3500
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 38100.0,
+        "tax_total": 4555.0,
+        "net_income": 31545.0
+      },
+      "details": {
+        "pension": {
+          "total_tax": 1760.0
+        },
+        "rental": {
+          "taxable_income": 13000.0,
+          "total_tax": 2150.0
+        },
+        "investment": {
+          "gross_income": 5100.0,
+          "total_tax": 645.0
+        }
+      }
+    }
+  }
+]

--- a/tests/integration/test_calculation_endpoint.py
+++ b/tests/integration/test_calculation_endpoint.py
@@ -1,0 +1,85 @@
+"""Integration tests for the tax calculation REST endpoint."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from pathlib import Path
+from typing import Dict, Iterable
+
+import pytest
+from flask.testing import FlaskClient
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "regression_scenarios.json"
+
+
+def _load_scenarios() -> Iterable[Dict[str, object]]:
+    with DATA_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.mark.parametrize("scenario", _load_scenarios(), ids=lambda item: item["name"])
+def test_calculation_endpoint_matches_regression_scenarios(
+    client: FlaskClient, scenario: Dict[str, object]
+) -> None:
+    """Each regression scenario should remain stable over time."""
+
+    response = client.post("/api/v1/calculations", json=scenario["payload"])
+    assert response.status_code == HTTPStatus.OK
+
+    result = response.get_json()
+    expected = scenario["expectations"]
+
+    summary = result["summary"]
+    for key, value in expected["summary"].items():
+        assert summary[key] == pytest.approx(value)
+
+    details = {item["category"]: item for item in result["details"]}
+    for category, expectations in expected["details"].items():
+        assert category in details, f"Missing detail for {category}"
+        for field, value in expectations.items():
+            assert details[category][field] == pytest.approx(value)
+
+
+def test_calculation_endpoint_uses_accept_language_header(client: FlaskClient) -> None:
+    """Accept-Language header should influence locale if body omits it."""
+
+    response = client.post(
+        "/api/v1/calculations",
+        json={"year": 2024, "employment": {"gross_income": 10_000}},
+        headers={"Accept-Language": "el"},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    payload = response.get_json()
+    assert payload["meta"]["locale"] == "el"
+    assert payload["summary"]["labels"]["income_total"] == "Συνολικό εισόδημα"
+
+
+def test_calculation_endpoint_returns_validation_error(client: FlaskClient) -> None:
+    """Invalid payloads should return a structured 400 response."""
+
+    response = client.post(
+        "/api/v1/calculations",
+        data="not-json",
+        content_type="text/plain",
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    payload = response.get_json()
+    assert payload["error"] == "bad_request"
+    assert "JSON" in payload["message"].upper()
+
+
+def test_calculation_endpoint_handles_service_errors(client: FlaskClient) -> None:
+    """Domain validation errors should surface as 400 responses."""
+
+    response = client.post(
+        "/api/v1/calculations",
+        json={"year": 2024, "employment": {"gross_income": -1}},
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    payload = response.get_json()
+    assert payload["error"] == "validation_error"
+    assert "cannot be negative" in payload["message"].lower()

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -1,17 +1,6 @@
 """Integration tests for application endpoints."""
 
-import pytest
 from flask.testing import FlaskClient
-
-from greektax.backend.app import create_app
-
-
-@pytest.fixture()
-def client() -> FlaskClient:
-    """Create a test client for the Flask app."""
-    app = create_app()
-    app.config.update(TESTING=True)
-    return app.test_client()
 
 
 def test_health_endpoint(client: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
- add a Flask blueprint that exposes POST /api/v1/calculations with locale-aware responses and JSON error handling
- add regression scenario fixtures and integration tests that cover the new endpoint plus Accept-Language behaviour
- wire a front-end language preview that persists locale selection, call the API, and document the sprint progress

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd0a33c654832481be76519d82ffc8