### PR TITLE
Enhance localisation and documentation for Sprint 5 deliverables

### DIFF
--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -21,11 +21,15 @@ Metadata endpoints support the front-end in building dynamic forms:
 ```
 GET /api/v1/config/years
 GET /api/v1/config/<year>/investment-categories?locale=<locale>
+GET /api/v1/config/<year>/deductions?locale=<locale>
 ```
 
 The first returns all configured tax years plus a suggested default. The second
 exposes investment income categories (identifier, rate, locale-aware label) for
-the requested year.
+the requested year. The third surfaces deduction hints for the UI, returning the
+deduction identifier, the applicable income categories, the translated display
+label and description, as well as validation metadata (e.g., minimum, maximum,
+or numeric type) to apply on the client.
 
 ## Request Body
 
@@ -46,6 +50,7 @@ the requested year.
 | `investment.*` | number | ❌ | Amounts for each configured investment category (e.g. `dividends`, `interest`, `capital_gains`, `royalties`). |
 | `obligations.vat` | number | ❌ | Value Added Tax due for the year. Included in totals without further calculation. |
 | `obligations.enfia` | number | ❌ | ENFIA property tax amount to include in the summary. |
+| `obligations.luxury` | number | ❌ | Luxury living tax amount for high-value assets. Added directly to the summary. |
 
 All numeric fields must be non-negative. Boolean fields accept `true`, `false`,
 and equivalent string toggles (`"yes"`, `"no"`, `"1"`, `"0"`, etc.). Missing

--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -66,17 +66,9 @@ deliver user value in incremental, testable slices.
 - Locale-aware preview controls on the front-end persisting user preferences.
 - Regression scenario catalogue underpinning integration coverage.
 
-## Sprint 4 (Current)
+## Sprint 4 (Completed)
 
-**Objectives**
-- Surface configuration metadata (available years, investment categories) for
-  dynamic UI rendering.
-- Wire the primary calculator form to the API, including printable/exportable
-  summaries.
-- Expand automated coverage to VAT and ENFIA obligations alongside existing
-  income scenarios.
-
-**Deliverables (to date)**
+**Highlights**
 - REST endpoints exposing available tax years and locale-aware investment
   categories.
 - Interactive calculator UI tied to the backend with download and print helpers
@@ -84,13 +76,31 @@ deliver user value in incremental, testable slices.
 - Regression scenarios and unit tests validating VAT/ENFIA obligations within
   the calculation engine.
 
-**Next Steps (Preview of Sprint 5)**
-- Introduce endpoints for year metadata beyond investment categories (e.g.
-  deductible catalogues) to power richer UI hints.
-- Implement client-side validation and localisation for the expanded form
-  fields.
-- Deliver shareable/print-ready summary layouts (PDF or HTML) and broaden
-  regression coverage to luxury tax and VAT edge cases.
+## Sprint 5 (Current)
+
+**Objectives**
+- Extend configuration metadata endpoints with deduction guidance for form
+  tooling.
+- Strengthen front-end localisation and validation across all calculator
+  controls.
+- Provide printable and shareable summaries while tightening regression coverage
+  around luxury-tax and VAT obligations.
+
+**Deliverables (to date)**
+- `/api/v1/config/<year>/deductions` endpoint returning locale-aware deduction
+  hints with validation metadata.
+- Calculator interface that localises static copy, labels, and validation
+  feedback when switching locales.
+- Shareable HTML summary generator and expanded regression scenarios including a
+  luxury-tax-only edge case.
+
+**Next Steps (Preview of Sprint 6)**
+- Publish richer deduction metadata (e.g., allowance thresholds) for enhanced UI
+  helpers and contextual education.
+- Explore downloadable PDF/CSV exports for summaries alongside persisted share
+  links.
+- Expand regression coverage to multi-year comparisons and printable export
+  rendering fidelity.
 
 > _This plan is updated at the end of each sprint to capture accomplishments_
 > _and upcoming milestones._

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -19,7 +19,20 @@ const STORAGE_KEY = "greektax.locale";
 
 const UI_MESSAGES = {
   en: {
+    ui: {
+      tagline: "Unofficial tax estimation toolkit for Greece",
+      overview_heading: "Overview",
+      overview_description:
+        "Estimate annual income taxes for Greece across employment, freelance, rental, and investment categories. Select a tax year, choose your language, and provide the income figures relevant to your situation to receive a bilingual breakdown of obligations.",
+      disclaimer:
+        "Disclaimer: This tool is unofficial and provided as-is without data storage. Please consult a professional accountant for formal filings.",
+    },
     preview: {
+      heading: "Preview localisation",
+      description:
+        "Choose your preferred language and request a sample calculation to see the backend translations in action. The preview uses demo data only.",
+      locale_label: "Language",
+      button: "Preview calculation",
       idle: "No preview requested yet.",
       requesting: "Requesting preview from the API…",
       success: "Preview updated using backend localisation.",
@@ -42,6 +55,18 @@ const UI_MESSAGES = {
       max_number: "{{field}} must be at most {{max}}.",
       non_integer: "{{field}} must be a whole number.",
     },
+    calculator: {
+      heading: "Tax calculator",
+      results_heading: "Results",
+      legends: {
+        year_household: "Year and household",
+        employment_pension: "Employment & pension income",
+        freelance: "Freelance income",
+        rental: "Rental income",
+        investment: "Investment income",
+        obligations: "Additional obligations",
+      },
+    },
     forms: {
       no_investment_categories: "No investment categories configured for this year.",
       share_title: "GreekTax summary",
@@ -63,25 +88,45 @@ const UI_MESSAGES = {
       breakdown: "Breakdown",
     },
     fields: {
-      year: "Tax year",
+      "year-select": "Tax year",
       "children-input": "Dependent children",
-      "employment-income": "Employment gross income",
-      "pension-income": "Pension gross income",
-      "freelance-revenue": "Freelance gross revenue",
-      "freelance-expenses": "Freelance deductible expenses",
-      "freelance-contributions": "Mandatory social contributions",
-      "rental-income": "Rental gross income",
-      "rental-expenses": "Rental deductible expenses",
-      "vat-due": "VAT due",
-      "enfia-due": "ENFIA amount",
-      "luxury-due": "Luxury living tax",
+      "employment-income": "Employment gross income (€)",
+      "pension-income": "Pension gross income (€)",
+      "freelance-revenue": "Freelance gross revenue (€)",
+      "freelance-expenses": "Freelance deductible expenses (€)",
+      "freelance-contributions": "Mandatory social contributions (€)",
+      "trade-fee-toggle": "Include business activity fee",
+      "rental-income": "Rental gross income (€)",
+      "rental-expenses": "Rental deductible expenses (€)",
+      "vat-due": "VAT due (€)",
+      "enfia-due": "ENFIA amount (€)",
+      "luxury-due": "Luxury living tax (€)",
+    },
+    actions: {
+      calculate: "Calculate taxes",
+      download: "Download summary (JSON)",
+      share: "Open shareable summary",
+      print: "Print summary",
     },
     share: {
       open_failed: "Popup blocked. Please allow pop-ups to view the summary.",
     },
   },
   el: {
+    ui: {
+      tagline: "Μη επίσημο εργαλείο εκτίμησης φόρων για την Ελλάδα",
+      overview_heading: "Επισκόπηση",
+      overview_description:
+        "Υπολογίστε ετήσιες φορολογικές υποχρεώσεις στην Ελλάδα για μισθωτούς, ελεύθερους επαγγελματίες, ενοίκια και επενδύσεις. Επιλέξτε φορολογικό έτος, γλώσσα και εισάγετε τα ποσά για να λάβετε δίγλωσση ανάλυση.",
+      disclaimer:
+        "Αποποίηση ευθύνης: Το εργαλείο είναι ανεπίσημο και παρέχεται ως έχει χωρίς αποθήκευση δεδομένων. Συμβουλευτείτε λογιστή για επίσημες δηλώσεις.",
+    },
     preview: {
+      heading: "Προεπισκόπηση εντοπισμού",
+      description:
+        "Επιλέξτε γλώσσα και ζητήστε δείγμα υπολογισμού για να δείτε τις μεταφράσεις του διακομιστή. Η προεπισκόπηση χρησιμοποιεί μόνο δοκιμαστικά δεδομένα.",
+      locale_label: "Γλώσσα",
+      button: "Προεπισκόπηση υπολογισμού",
       idle: "Δεν έχει ζητηθεί προεπισκόπηση ακόμη.",
       requesting: "Αίτημα προεπισκόπησης προς το API…",
       success: "Η προεπισκόπηση ενημερώθηκε με τις μεταφράσεις του διακομιστή.",
@@ -103,6 +148,18 @@ const UI_MESSAGES = {
       min_number: "{{field}} πρέπει να είναι τουλάχιστον {{min}}.",
       max_number: "{{field}} πρέπει να είναι το πολύ {{max}}.",
       non_integer: "{{field}} πρέπει να είναι ακέραιος αριθμός.",
+    },
+    calculator: {
+      heading: "Φορολογικός υπολογιστής",
+      results_heading: "Αποτελέσματα",
+      legends: {
+        year_household: "Έτος και νοικοκυριό",
+        employment_pension: "Εισόδημα μισθωτών & συντάξεων",
+        freelance: "Εισόδημα ελεύθερου επαγγελματία",
+        rental: "Εισόδημα από ενοίκια",
+        investment: "Επενδυτικά εισοδήματα",
+        obligations: "Πρόσθετες υποχρεώσεις",
+      },
     },
     forms: {
       no_investment_categories:
@@ -126,18 +183,25 @@ const UI_MESSAGES = {
       breakdown: "Ανάλυση",
     },
     fields: {
-      year: "Φορολογικό έτος",
+      "year-select": "Φορολογικό έτος",
       "children-input": "Εξαρτώμενα τέκνα",
-      "employment-income": "Ακαθάριστο εισόδημα μισθωτών",
-      "pension-income": "Ακαθάριστο εισόδημα συντάξεων",
-      "freelance-revenue": "Ακαθάριστα έσοδα ελευθέρου επαγγελματία",
-      "freelance-expenses": "Εκπιπτόμενες δαπάνες ελευθέρου επαγγελματία",
-      "freelance-contributions": "Υποχρεωτικές εισφορές",
-      "rental-income": "Ακαθάριστα έσοδα ενοικίων",
-      "rental-expenses": "Εκπιπτόμενες δαπάνες ενοικίων",
-      "vat-due": "Οφειλόμενος ΦΠΑ",
-      "enfia-due": "Ποσό ΕΝΦΙΑ",
-      "luxury-due": "Φόρος πολυτελούς διαβίωσης",
+      "employment-income": "Ακαθάριστο εισόδημα μισθωτών (€)",
+      "pension-income": "Ακαθάριστο εισόδημα συντάξεων (€)",
+      "freelance-revenue": "Ακαθάριστα έσοδα ελευθέρου επαγγελματία (€)",
+      "freelance-expenses": "Εκπιπτόμενες δαπάνες ελευθέρου επαγγελματία (€)",
+      "freelance-contributions": "Υποχρεωτικές εισφορές (€)",
+      "trade-fee-toggle": "Συμπερίληψη τέλους επιτηδεύματος",
+      "rental-income": "Ακαθάριστα έσοδα ενοικίων (€)",
+      "rental-expenses": "Εκπιπτόμενες δαπάνες ενοικίων (€)",
+      "vat-due": "Οφειλόμενος ΦΠΑ (€)",
+      "enfia-due": "Ποσό ΕΝΦΙΑ (€)",
+      "luxury-due": "Φόρος πολυτελούς διαβίωσης (€)",
+    },
+    actions: {
+      calculate: "Υπολογισμός φόρων",
+      download: "Λήψη σύνοψης (JSON)",
+      share: "Άνοιγμα κοινόχρηστης σύνοψης",
+      print: "Εκτύπωση σύνοψης",
     },
     share: {
       open_failed:
@@ -258,6 +322,7 @@ function applyLocale(locale) {
   currentLocale = locale;
   persistLocale(locale);
   document.documentElement.lang = locale === "el" ? "el" : "en";
+  localiseStaticText();
   if (localeSelect) {
     localeSelect.value = locale;
   }
@@ -266,6 +331,19 @@ function applyLocale(locale) {
   }
   refreshInvestmentCategories();
   refreshDeductionHints();
+}
+
+function localiseStaticText() {
+  document.querySelectorAll("[data-i18n-key]").forEach((element) => {
+    const key = element.getAttribute("data-i18n-key");
+    if (!key) {
+      return;
+    }
+    const message = t(key);
+    if (typeof message === "string") {
+      element.textContent = message;
+    }
+  });
 }
 
 function updatePreviewIdleMessage() {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -9,19 +9,21 @@
   <body>
     <header class="no-print">
       <h1>GreekTax</h1>
-      <p class="tagline">Unofficial tax estimation toolkit for Greece</p>
+      <p class="tagline" data-i18n-key="ui.tagline">
+        Unofficial tax estimation toolkit for Greece
+      </p>
     </header>
 
     <main>
       <section id="app-intro" class="card">
-        <h2>Overview</h2>
-        <p>
+        <h2 data-i18n-key="ui.overview_heading">Overview</h2>
+        <p data-i18n-key="ui.overview_description">
           Estimate annual income taxes for Greece across employment, freelance,
           rental, and investment categories. Select a tax year, choose your
           language, and provide the income figures relevant to your situation to
           receive a bilingual breakdown of obligations.
         </p>
-        <p class="disclaimer">
+        <p class="disclaimer" data-i18n-key="ui.disclaimer">
           Disclaimer: This tool is unofficial and provided as-is without data
           storage. Please consult a professional accountant for formal filings.
         </p>
@@ -32,20 +34,29 @@
         class="card no-print"
         aria-labelledby="language-preview-title"
       >
-        <h2 id="language-preview-title">Preview localisation</h2>
-        <p>
+        <h2 id="language-preview-title" data-i18n-key="preview.heading">
+          Preview localisation
+        </h2>
+        <p data-i18n-key="preview.description">
           Choose your preferred language and request a sample calculation to see
           the backend translations in action. The preview uses demo data only.
         </p>
         <form id="locale-form" class="stack" novalidate>
           <div class="form-control">
-            <label for="locale-select">Language</label>
+            <label for="locale-select" data-i18n-key="preview.locale_label">
+              Language
+            </label>
             <select id="locale-select" name="locale">
               <option value="en">English</option>
               <option value="el">Ελληνικά</option>
             </select>
           </div>
-          <button type="button" id="preview-button" class="button">
+          <button
+            type="button"
+            id="preview-button"
+            class="button"
+            data-i18n-key="preview.button"
+          >
             Preview calculation
           </button>
         </form>
@@ -56,17 +67,31 @@
       </section>
 
       <section id="calculator" class="card" aria-labelledby="calculator-title">
-        <h2 id="calculator-title">Tax calculator</h2>
+        <h2 id="calculator-title" data-i18n-key="calculator.heading">
+          Tax calculator
+        </h2>
         <form id="calculator-form" novalidate>
           <fieldset class="fieldset">
-            <legend>Year and household</legend>
+            <legend data-i18n-key="calculator.legends.year_household">
+              Year and household
+            </legend>
             <div class="form-grid double">
               <div class="form-control">
-                <label for="year-select">Tax year</label>
+                <label
+                  for="year-select"
+                  data-i18n-key="fields.year-select"
+                >
+                  Tax year
+                </label>
                 <select id="year-select" name="year"></select>
               </div>
               <div class="form-control">
-                <label for="children-input">Dependent children</label>
+                <label
+                  for="children-input"
+                  data-i18n-key="fields.children-input"
+                >
+                  Dependent children
+                </label>
                 <input
                   id="children-input"
                   name="dependents.children"
@@ -80,10 +105,17 @@
           </fieldset>
 
           <fieldset class="fieldset">
-            <legend>Employment &amp; pension income</legend>
+            <legend data-i18n-key="calculator.legends.employment_pension">
+              Employment &amp; pension income
+            </legend>
             <div class="form-grid double">
               <div class="form-control">
-                <label for="employment-income">Employment gross income (€)</label>
+                <label
+                  for="employment-income"
+                  data-i18n-key="fields.employment-income"
+                >
+                  Employment gross income (€)
+                </label>
                 <input
                   id="employment-income"
                   name="employment.gross_income"
@@ -94,7 +126,12 @@
                 />
               </div>
               <div class="form-control">
-                <label for="pension-income">Pension gross income (€)</label>
+                <label
+                  for="pension-income"
+                  data-i18n-key="fields.pension-income"
+                >
+                  Pension gross income (€)
+                </label>
                 <input
                   id="pension-income"
                   name="pension.gross_income"
@@ -108,10 +145,17 @@
           </fieldset>
 
           <fieldset class="fieldset">
-            <legend>Freelance income</legend>
+            <legend data-i18n-key="calculator.legends.freelance">
+              Freelance income
+            </legend>
             <div class="form-grid double">
               <div class="form-control">
-                <label for="freelance-revenue">Gross revenue (€)</label>
+                <label
+                  for="freelance-revenue"
+                  data-i18n-key="fields.freelance-revenue"
+                >
+                  Gross revenue (€)
+                </label>
                 <input
                   id="freelance-revenue"
                   name="freelance.gross_revenue"
@@ -122,7 +166,12 @@
                 />
               </div>
               <div class="form-control">
-                <label for="freelance-expenses">Deductible expenses (€)</label>
+                <label
+                  for="freelance-expenses"
+                  data-i18n-key="fields.freelance-expenses"
+                >
+                  Deductible expenses (€)
+                </label>
                 <input
                   id="freelance-expenses"
                   name="freelance.deductible_expenses"
@@ -133,7 +182,10 @@
                 />
               </div>
               <div class="form-control">
-                <label for="freelance-contributions">
+                <label
+                  for="freelance-contributions"
+                  data-i18n-key="fields.freelance-contributions"
+                >
                   Mandatory social contributions (€)
                 </label>
                 <input
@@ -153,17 +205,29 @@
                     name="freelance.include_trade_fee"
                     checked
                   />
-                  <label for="trade-fee-toggle">Include business activity fee</label>
+                  <label
+                    for="trade-fee-toggle"
+                    data-i18n-key="fields.trade-fee-toggle"
+                  >
+                    Include business activity fee
+                  </label>
                 </span>
               </div>
             </div>
           </fieldset>
 
           <fieldset class="fieldset">
-            <legend>Rental income</legend>
+            <legend data-i18n-key="calculator.legends.rental">
+              Rental income
+            </legend>
             <div class="form-grid double">
               <div class="form-control">
-                <label for="rental-income">Gross rental income (€)</label>
+                <label
+                  for="rental-income"
+                  data-i18n-key="fields.rental-income"
+                >
+                  Gross rental income (€)
+                </label>
                 <input
                   id="rental-income"
                   name="rental.gross_income"
@@ -174,7 +238,12 @@
                 />
               </div>
               <div class="form-control">
-                <label for="rental-expenses">Deductible expenses (€)</label>
+                <label
+                  for="rental-expenses"
+                  data-i18n-key="fields.rental-expenses"
+                >
+                  Deductible expenses (€)
+                </label>
                 <input
                   id="rental-expenses"
                   name="rental.deductible_expenses"
@@ -188,15 +257,21 @@
           </fieldset>
 
           <fieldset class="fieldset">
-            <legend>Investment income</legend>
+            <legend data-i18n-key="calculator.legends.investment">
+              Investment income
+            </legend>
             <div id="investment-fields" class="form-grid double"></div>
           </fieldset>
 
           <fieldset class="fieldset">
-            <legend>Additional obligations</legend>
+            <legend data-i18n-key="calculator.legends.obligations">
+              Additional obligations
+            </legend>
             <div class="form-grid double">
               <div class="form-control">
-                <label for="vat-due">VAT due (€)</label>
+                <label for="vat-due" data-i18n-key="fields.vat-due">
+                  VAT due (€)
+                </label>
                 <input
                   id="vat-due"
                   name="obligations.vat"
@@ -207,7 +282,9 @@
                 />
               </div>
               <div class="form-control">
-                <label for="enfia-due">ENFIA amount (€)</label>
+                <label for="enfia-due" data-i18n-key="fields.enfia-due">
+                  ENFIA amount (€)
+                </label>
                 <input
                   id="enfia-due"
                   name="obligations.enfia"
@@ -218,7 +295,9 @@
                 />
               </div>
               <div class="form-control">
-                <label for="luxury-due">Luxury living tax (€)</label>
+                <label for="luxury-due" data-i18n-key="fields.luxury-due">
+                  Luxury living tax (€)
+                </label>
                 <input
                   id="luxury-due"
                   name="obligations.luxury"
@@ -232,16 +311,39 @@
           </fieldset>
 
           <div class="actions">
-            <button type="submit" class="button" id="calculate-button">
+            <button
+              type="submit"
+              class="button"
+              id="calculate-button"
+              data-i18n-key="actions.calculate"
+            >
               Calculate taxes
             </button>
-            <button type="button" class="button secondary" id="download-button" disabled>
+            <button
+              type="button"
+              class="button secondary"
+              id="download-button"
+              data-i18n-key="actions.download"
+              disabled
+            >
               Download summary (JSON)
             </button>
-            <button type="button" class="button ghost" id="share-button" disabled>
+            <button
+              type="button"
+              class="button ghost"
+              id="share-button"
+              data-i18n-key="actions.share"
+              disabled
+            >
               Open shareable summary
             </button>
-            <button type="button" class="button ghost" id="print-button" disabled>
+            <button
+              type="button"
+              class="button ghost"
+              id="print-button"
+              data-i18n-key="actions.print"
+              disabled
+            >
               Print summary
             </button>
           </div>
@@ -249,7 +351,7 @@
         </form>
 
         <section id="calculation-results" hidden aria-live="polite">
-          <h3>Results</h3>
+          <h3 data-i18n-key="calculator.results_heading">Results</h3>
           <div class="summary-grid" id="summary-grid"></div>
           <div class="details-list" id="details-list"></div>
         </section>

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -104,5 +104,27 @@
         }
       }
     }
+  },
+  {
+    "name": "luxury_obligation_only",
+    "payload": {
+      "year": 2024,
+      "obligations": {
+        "luxury": 925.75
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 0.0,
+        "tax_total": 925.75,
+        "net_income": -925.75
+      },
+      "details": {
+        "luxury": {
+          "total_tax": 925.75,
+          "net_income": -925.75
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- localise the calculator interface using shared UI message catalogues and apply translated copy across form controls
- document the new deduction metadata endpoint and luxury tax obligation input exposed by the API
- expand regression scenarios to cover the luxury-tax only case and update the project plan for Sprint 5 objectives

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd1eeda85883249a226423ff84ad4a