### PR TITLE
Expose payroll metadata and finish net/gross UI

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -132,6 +132,10 @@ header {
   gap: 0.35rem;
 }
 
+.form-control[hidden] {
+  display: none !important;
+}
+
 .form-control label {
   font-weight: 600;
 }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -111,6 +111,53 @@
             <div class="form-grid double">
               <div class="form-control">
                 <label
+                  for="employment-mode"
+                  data-i18n-key="fields.employment-mode"
+                >
+                  Salary input type
+                </label>
+                <select id="employment-mode">
+                  <option
+                    value="gross"
+                    data-i18n-key="fields.employment-mode-gross"
+                  >
+                    Enter gross amounts
+                  </option>
+                  <option
+                    value="net"
+                    data-i18n-key="fields.employment-mode-net"
+                  >
+                    Enter net amounts
+                  </option>
+                </select>
+              </div>
+              <div class="form-control">
+                <label
+                  for="employment-payments"
+                  data-i18n-key="fields.employment-payments"
+                >
+                  Salary payments per year
+                </label>
+                <select
+                  id="employment-payments"
+                  name="employment.payments_per_year"
+                  aria-describedby="employment-payments-hint"
+                ></select>
+                <p
+                  id="employment-payments-hint"
+                  class="form-hint"
+                  data-static-hint="true"
+                  data-i18n-key="hints.employment-payments"
+                >
+                  Most salaried roles use 14 payments (12 monthly + bonuses).
+                </p>
+              </div>
+              <div
+                class="form-control"
+                data-section="employment"
+                data-mode="gross"
+              >
+                <label
                   for="employment-income"
                   data-i18n-key="fields.employment-income"
                 >
@@ -125,7 +172,11 @@
                   value="0"
                 />
               </div>
-              <div class="form-control">
+              <div
+                class="form-control"
+                data-section="employment"
+                data-mode="gross"
+              >
                 <label
                   for="employment-monthly-income"
                   data-i18n-key="fields.employment-monthly-income"
@@ -141,33 +192,87 @@
                   value="0"
                 />
               </div>
-              <div class="form-control">
+              <div
+                class="form-control"
+                data-section="employment"
+                data-mode="net"
+                hidden
+              >
                 <label
-                  for="employment-payments"
-                  data-i18n-key="fields.employment-payments"
+                  for="employment-net-income"
+                  data-i18n-key="fields.employment-net-income"
                 >
-                  Salary payments per year
+                  Annual net income (€)
                 </label>
                 <input
-                  id="employment-payments"
-                  name="employment.payments_per_year"
+                  id="employment-net-income"
+                  name="employment.net_income"
                   type="number"
-                  min="1"
-                  max="24"
-                  step="1"
-                  value="14"
-                  aria-describedby="employment-payments-hint"
+                  min="0"
+                  step="0.01"
+                  value="0"
                 />
-                <p
-                  id="employment-payments-hint"
-                  class="form-hint"
-                  data-static-hint="true"
-                  data-i18n-key="hints.employment-payments"
+              </div>
+              <div
+                class="form-control"
+                data-section="employment"
+                data-mode="net"
+                hidden
+              >
+                <label
+                  for="employment-net-monthly-income"
+                  data-i18n-key="fields.employment-net-monthly-income"
                 >
-                  Most salaried roles use 14 payments (12 monthly + bonuses).
-                </p>
+                  Net income per payment (€)
+                </label>
+                <input
+                  id="employment-net-monthly-income"
+                  name="employment.net_monthly_income"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value="0"
+                />
               </div>
               <div class="form-control">
+                <label
+                  for="pension-mode"
+                  data-i18n-key="fields.pension-mode"
+                >
+                  Pension input type
+                </label>
+                <select id="pension-mode">
+                  <option
+                    value="gross"
+                    data-i18n-key="fields.pension-mode-gross"
+                  >
+                    Enter gross amounts
+                  </option>
+                  <option
+                    value="net"
+                    data-i18n-key="fields.pension-mode-net"
+                  >
+                    Enter net amounts
+                  </option>
+                </select>
+              </div>
+              <div class="form-control">
+                <label
+                  for="pension-payments"
+                  data-i18n-key="fields.pension-payments"
+                >
+                  Pension payments per year
+                </label>
+                <select
+                  id="pension-payments"
+                  name="pension.payments_per_year"
+                ></select>
+              </div>
+              <div
+                class="form-control"
+                data-section="pension"
+                data-mode="gross"
+              >
                 <label
                   for="pension-income"
                   data-i18n-key="fields.pension-income"
@@ -177,6 +282,48 @@
                 <input
                   id="pension-income"
                   name="pension.gross_income"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value="0"
+                />
+              </div>
+              <div
+                class="form-control"
+                data-section="pension"
+                data-mode="net"
+                hidden
+              >
+                <label
+                  for="pension-net-income"
+                  data-i18n-key="fields.pension-net-income"
+                >
+                  Annual net pension (€)
+                </label>
+                <input
+                  id="pension-net-income"
+                  name="pension.net_income"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value="0"
+                />
+              </div>
+              <div
+                class="form-control"
+                data-section="pension"
+                data-mode="net"
+                hidden
+              >
+                <label
+                  for="pension-net-monthly-income"
+                  data-i18n-key="fields.pension-net-monthly-income"
+                >
+                  Net pension per payment (€)
+                </label>
+                <input
+                  id="pension-net-monthly-income"
+                  name="pension.net_monthly_income"
                   type="number"
                   min="0"
                   step="0.01"

--- a/src/greektax/backend/config/data/2024.yaml
+++ b/src/greektax/backend/config/data/2024.yaml
@@ -5,6 +5,14 @@ meta:
   notes: "Initial 2024 configuration with employment and freelance coverage"
 income:
   employment:
+    payroll:
+      allowed_payments_per_year:
+        - 14
+        - 12
+      default_payments_per_year: 14
+    contributions:
+      employee_rate: 0.1387
+      employer_rate: 0.2243
     tax_brackets:
       - upper: 10000
         rate: 0.09
@@ -23,6 +31,13 @@ income:
         "3": 1120
       incremental_amount_per_child: 220
   pension:
+    payroll:
+      allowed_payments_per_year:
+        - 14
+      default_payments_per_year: 14
+    contributions:
+      employee_rate: 0.0
+      employer_rate: 0.0
     tax_brackets:
       - upper: 10000
         rate: 0.09

--- a/src/greektax/backend/config/data/2025.yaml
+++ b/src/greektax/backend/config/data/2025.yaml
@@ -5,6 +5,14 @@ meta:
   notes: "Draft 2025 configuration with updated family tax credits"
 income:
   employment:
+    payroll:
+      allowed_payments_per_year:
+        - 14
+        - 12
+      default_payments_per_year: 14
+    contributions:
+      employee_rate: 0.1387
+      employer_rate: 0.2243
     tax_brackets:
       - upper: 10000
         rate: 0.09
@@ -23,6 +31,13 @@ income:
         "3": 1140
       incremental_amount_per_child: 230
   pension:
+    payroll:
+      allowed_payments_per_year:
+        - 14
+      default_payments_per_year: 14
+    contributions:
+      employee_rate: 0.0
+      employer_rate: 0.0
     tax_brackets:
       - upper: 10000
         rate: 0.09

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -4,8 +4,12 @@
     "payload": {
       "year": 2024,
       "locale": "en",
-      "dependents": {"children": 0},
-      "employment": {"gross_income": 20000},
+      "dependents": {
+        "children": 0
+      },
+      "employment": {
+        "gross_income": 20000
+      },
       "freelance": {
         "gross_revenue": 18000,
         "deductible_expenses": 4000,
@@ -16,7 +20,7 @@
       "summary": {
         "income_total": 34000.0,
         "tax_total": 6133.0,
-        "net_income": 24867.0,
+        "net_income": 22093.0,
         "average_monthly_tax": 511.08
       },
       "details": {
@@ -34,8 +38,12 @@
     "name": "pension_rental_investment_obligations",
     "payload": {
       "year": 2024,
-      "dependents": {"children": 2},
-      "pension": {"gross_income": 18000},
+      "dependents": {
+        "children": 2
+      },
+      "pension": {
+        "gross_income": 18000
+      },
       "rental": {
         "gross_income": 15000,
         "deductible_expenses": 2000
@@ -145,7 +153,7 @@
       "summary": {
         "income_total": 25900.0,
         "tax_total": 3975.0,
-        "net_income": 21925.0,
+        "net_income": 18332.67,
         "average_monthly_tax": 331.25
       },
       "details": {
@@ -155,7 +163,7 @@
           "total_tax": 3975.0,
           "payments_per_year": 14,
           "gross_income_per_payment": 1850.0,
-          "net_income_per_payment": 1566.07
+          "net_income_per_payment": 1309.48
         }
       }
     }
@@ -164,14 +172,18 @@
     "name": "employment_large_family_credit_allocation",
     "payload": {
       "year": 2024,
-      "dependents": {"children": 3},
-      "employment": {"gross_income": 42000}
+      "dependents": {
+        "children": 3
+      },
+      "employment": {
+        "gross_income": 42000
+      }
     },
     "expectations": {
       "summary": {
         "income_total": 42000.0,
         "tax_total": 9260.0,
-        "net_income": 32740.0,
+        "net_income": 26914.6,
         "average_monthly_tax": 771.67
       },
       "details": {
@@ -187,15 +199,21 @@
     "name": "employment_pension_credit_share",
     "payload": {
       "year": 2024,
-      "dependents": {"children": 1},
-      "employment": {"gross_income": 22000},
-      "pension": {"gross_income": 8000}
+      "dependents": {
+        "children": 1
+      },
+      "employment": {
+        "gross_income": 22000
+      },
+      "pension": {
+        "gross_income": 8000
+      }
     },
     "expectations": {
       "summary": {
         "income_total": 30000.0,
         "tax_total": 5090.0,
-        "net_income": 24910.0,
+        "net_income": 21858.6,
         "average_monthly_tax": 424.17
       },
       "details": {

--- a/tests/integration/test_config_endpoints.py
+++ b/tests/integration/test_config_endpoints.py
@@ -15,6 +15,16 @@ def test_list_years_endpoint(client: FlaskClient) -> None:
     assert any(entry["year"] == 2025 for entry in years)
     assert payload["default_year"] == 2025
 
+    current_year = next(entry for entry in years if entry["year"] == 2025)
+    employment_meta = current_year["employment"]
+    assert employment_meta["payroll"]["default_payments_per_year"] == 14
+    assert 12 in employment_meta["payroll"]["allowed_payments_per_year"]
+    assert employment_meta["contributions"]["employee_rate"] >= 0
+
+    pension_meta = current_year["pension"]
+    assert pension_meta["payroll"]["allowed_payments_per_year"]
+    assert pension_meta["contributions"]["employer_rate"] >= 0
+
 
 def test_investment_categories_endpoint(client: FlaskClient) -> None:
     response = client.get("/api/v1/config/2024/investment-categories?locale=el")


### PR DESCRIPTION
## Summary
- extend the config years endpoint to return payroll frequencies and EFKA contribution rates for employment and pension consumers
- finalise the calculator front-end to toggle gross/net modes, populate payroll options from metadata, and surface contribution fields in the results and exports
- ensure hidden controls collapse cleanly in the layout and extend integration coverage for the new metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd45266db8832486f3cac67d5d06ff