### PR TITLE
Add year warnings and optional employment toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Run the placeholder tests to validate the scaffold:
 pytest
 ```
 
+Validate configuration files to surface contributor-facing alerts:
+
+```bash
+python -m greektax.backend.config.validator
+```
+
 Additional tooling configured for future sprints:
 
 - `ruff` for linting (`ruff check src tests`)

--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -174,33 +174,44 @@ deliver user value in incremental, testable slices.
   with validation, configuration, and localisation priorities captured for the
   team.
 
-## Sprint 14 (Current)
+## Sprint 14 (Completed)
+
+**Highlights**
+- Expanded the year configuration schema with trade-fee sunset metadata,
+  structured warnings, and richer payroll options surfaced through the API and
+  UI alerts.
+- Delivered front-end affordances for year-specific guidance, including toggleable
+  employment inputs, contextual alerts, and localisation updates spanning copy
+  and validation hints.
+- Broadened automated coverage with regression scenarios focused on partial-year
+  employment, exemption handling, and pension payment frequencies alongside new
+  integration tests for configuration warnings.
+
+## Sprint 15 (Current)
 
 **Objectives**
-- Validate the delivered payroll, EFKA, and deduction flows with domain
-  specialists while broadening regression coverage for partial-year and
-  exemption scenarios.【F:docs/ui_improvement_plan.md†L13-L73】
-- Extend configuration coverage for anticipated legislative changes—such as
-  trade-fee sunsets—and surface alerts when year data is incomplete or
-  inconsistent.【F:docs/ui_improvement_plan.md†L75-L118】
-- Strengthen localisation guidance and contextual education so users can
-  navigate the expanded data-entry workload confidently.【F:docs/ui_improvement_plan.md†L13-L73】
-
-**Planned Deliverables**
-- Regression scenario updates capturing partial-year, exempt-profession, and
-  payroll edge cases reviewed with subject-matter experts.
-- Configuration schema enhancements to represent trade-fee sunsets and
-  incomplete-data warnings wired into the API contract and UI.
-- Localised guidance assets (tooltips, documentation hooks, telemetry checkpoints)
-  that highlight deduction rules and contribution expectations.
-
-**Next Steps (Preview of Sprint 15)**
 - Prototype automated configuration validation pipelines and contributor alerts
   to keep annual updates reliable.
 - Explore lightweight, privacy-preserving scenario exports that build on the
-  new local persistence capability without introducing server storage.
+  local persistence capability without introducing server storage.
 - Prepare usability test scripts focusing on the enriched localisation guidance
   to feed into post-Sprint-14 refinements.
+
+**Planned Deliverables**
+- Command-line tooling and automated checks that validate configuration files
+  before acceptance into the codebase.
+- Design notes or prototypes demonstrating how saved scenarios could be exported
+  without server-side storage while maintaining privacy guarantees.
+- Usability test scripts and localisation checklists ready for stakeholder
+  sessions covering the refreshed calculator flows.
+
+**Next Steps (Preview of Sprint 16)**
+- Integrate configuration validation into continuous integration and contributor
+  onboarding materials, capturing remediation guidance for common issues.
+- Iterate on scenario export concepts with accessibility and offline-use
+  considerations informed by Sprint 15 learnings.
+- Run moderated usability sessions and translate findings into backlog items for
+  post-Sprint-15 refinements.
 
 > _This plan is updated at the end of each sprint to capture accomplishments_
 > _and upcoming milestones._

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -131,6 +131,7 @@ const UI_MESSAGES = {
       "freelance-years-active": "Years self-employed",
       "freelance-newly-self-employed": "Newly self-employed",
       "trade-fee-toggle": "Include business activity fee",
+      "toggle-employment": "Include salary income",
       "toggle-freelance": "Include freelance income",
       "toggle-agricultural": "Include agricultural income",
       "toggle-other": "Include other income",
@@ -172,6 +173,36 @@ const UI_MESSAGES = {
       "freelance-efka-category-auxiliary": "Auxiliary fund contribution: {{amount}} per month.",
       "freelance-trade-fee": "Trade fee applied: {{amount}}.",
       "freelance-trade-fee-new": "Reduced rate applies for the first {{years}} years of activity.",
+      "freelance-trade-fee-sunset":
+        "The trade fee is scheduled to change from {{year}} (status: {{status}}). Confirm any exemptions with your accountant.",
+    },
+    warnings: {
+      learn_more: "Learn more",
+      employment: {
+        partial_year_review:
+          "Partial-year payroll scenarios may require manual EFKA and tax credit adjustments. Validate the figures for {{year}} if your contract ended early.",
+      },
+      freelance: {
+        trade_fee_sunset:
+          "Legislated trade-fee changes are pending final confirmation. Verify whether the business activity fee applies for {{year}} before filing.",
+      },
+      configuration: {
+        pending_deductions_2025:
+          "Some deduction thresholds for {{year}} are under review by tax authorities. Double-check deductible amounts before submitting returns.",
+      },
+      links: {
+        partial_year_review: "Guidance on partial-year payroll",
+        pending_deductions: "AADE deduction guidance",
+      },
+    },
+    links: {
+      trade_fee_sunset: "AADE trade fee update",
+    },
+    statuses: {
+      trade_fee: {
+        scheduled: "scheduled",
+        proposed: "proposed",
+      },
     },
     actions: {
       calculate: "Calculate taxes",
@@ -292,6 +323,7 @@ const UI_MESSAGES = {
       "freelance-years-active": "Έτη ως ελεύθερος επαγγελματίας",
       "freelance-newly-self-employed": "Νεοσύστατος επαγγελματίας",
       "trade-fee-toggle": "Συμπερίληψη τέλους επιτηδεύματος",
+      "toggle-employment": "Συμπερίληψη μισθολογικού εισοδήματος",
       "toggle-freelance": "Συμπερίληψη εισοδήματος ελευθέρων επαγγελματιών",
       "toggle-agricultural": "Συμπερίληψη αγροτικού εισοδήματος",
       "toggle-other": "Συμπερίληψη λοιπών εισοδημάτων",
@@ -333,6 +365,36 @@ const UI_MESSAGES = {
       "freelance-efka-category-auxiliary": "Εισφορά επικουρικού ταμείου: {{amount}} ανά μήνα.",
       "freelance-trade-fee": "Εφαρμοζόμενο τέλος επιτηδεύματος: {{amount}}.",
       "freelance-trade-fee-new": "Ισχύει μειωμένο ποσό για τα πρώτα {{years}} έτη δραστηριότητας.",
+      "freelance-trade-fee-sunset":
+        "Το τέλος επιτηδεύματος αναμένεται να αλλάξει από {{year}} (κατάσταση: {{status}}). Επιβεβαιώστε τυχόν απαλλαγές με τον λογιστή σας.",
+    },
+    warnings: {
+      learn_more: "Μάθετε περισσότερα",
+      employment: {
+        partial_year_review:
+          "Τα σενάρια με μερική απασχόληση ενδέχεται να απαιτούν χειροκίνητη προσαρμογή εισφορών και πιστώσεων. Επαληθεύστε τα ποσά για το {{year}} αν η σύμβασή σας έληξε νωρίτερα.",
+      },
+      freelance: {
+        trade_fee_sunset:
+          "Οι αλλαγές στο τέλος επιτηδεύματος εκκρεμούν για οριστικοποίηση. Βεβαιωθείτε ότι ισχύει για το {{year}} πριν από την υποβολή.",
+      },
+      configuration: {
+        pending_deductions_2025:
+          "Ορισμένα όρια εκπτώσεων για το {{year}} βρίσκονται υπό επανεξέταση. Ελέγξτε ξανά τα ποσά πριν τα δηλώσετε.",
+      },
+      links: {
+        partial_year_review: "Οδηγίες για μερική απασχόληση",
+        pending_deductions: "Οδηγός εκπτώσεων ΑΑΔΕ",
+      },
+    },
+    links: {
+      trade_fee_sunset: "Ενημέρωση ΑΑΔΕ για τέλος επιτηδεύματος",
+    },
+    statuses: {
+      trade_fee: {
+        scheduled: "προγραμματισμένο",
+        proposed: "υπό πρόταση",
+      },
     },
     actions: {
       calculate: "Υπολογισμός φόρων",
@@ -376,6 +438,7 @@ const employmentNetMonthlyIncomeInput = document.getElementById(
   "employment-net-monthly-income",
 );
 const employmentPaymentsInput = document.getElementById("employment-payments");
+const yearAlertsContainer = document.getElementById("year-alerts");
 const pensionModeSelect = document.getElementById("pension-mode");
 const pensionPaymentsInput = document.getElementById("pension-payments");
 const pensionIncomeInput = document.getElementById("pension-income");
@@ -424,6 +487,7 @@ const investmentSection = document.getElementById("investment-section");
 const deductionsSection = document.getElementById("deductions-section");
 const obligationsSection = document.getElementById("obligations-section");
 const toggleFreelance = document.getElementById("toggle-freelance");
+const toggleEmployment = document.getElementById("toggle-employment");
 const toggleAgricultural = document.getElementById("toggle-agricultural");
 const toggleOther = document.getElementById("toggle-other");
 const toggleRental = document.getElementById("toggle-rental");
@@ -785,7 +849,14 @@ function resetSectionInputs(section) {
     if (!select) {
       return;
     }
-    select.selectedIndex = 0;
+    const defaultValue = select.dataset.defaultValue;
+    if (defaultValue !== undefined) {
+      select.value = defaultValue;
+    } else if (select.options.length > 0) {
+      select.selectedIndex = 0;
+    } else {
+      select.value = "";
+    }
   });
 }
 
@@ -811,6 +882,7 @@ function handleSectionToggle(toggle) {
 
 function initialiseSectionToggles() {
   const toggles = [
+    toggleEmployment,
     toggleFreelance,
     toggleAgricultural,
     toggleOther,
@@ -902,6 +974,7 @@ function applyPendingCalculatorState() {
   }
 
   const toggles = [
+    toggleEmployment,
     toggleFreelance,
     toggleAgricultural,
     toggleOther,
@@ -989,6 +1062,7 @@ function populatePayrollSelect(select, payrollConfig) {
 
   const defaultValue = fallback || allowed[allowed.length - 1];
   select.value = String(defaultValue);
+  select.dataset.defaultValue = String(defaultValue);
   select.disabled = false;
 }
 
@@ -1015,8 +1089,71 @@ function resolvePaymentsValue(select, section) {
   return typeof fallback === "number" && fallback > 0 ? fallback : undefined;
 }
 
+function renderYearWarnings(metadata) {
+  if (!yearAlertsContainer) {
+    return;
+  }
+
+  yearAlertsContainer.innerHTML = "";
+  const warnings = Array.isArray(metadata?.warnings) ? metadata.warnings : [];
+  if (!warnings.length) {
+    yearAlertsContainer.hidden = true;
+    return;
+  }
+
+  warnings.forEach((warning) => {
+    if (!warning) {
+      return;
+    }
+
+    const severity = String(warning.severity || "info").toLowerCase();
+    const classes = ["alert"];
+    if (severity === "warning") {
+      classes.push("alert--warning");
+    } else if (severity === "error") {
+      classes.push("alert--error");
+    }
+
+    const alert = document.createElement("div");
+    alert.className = classes.join(" ");
+
+    const message = document.createElement("p");
+    message.className = "alert__message";
+    const replacements = {};
+    if (metadata?.year) {
+      replacements.year = metadata.year;
+    }
+    if (Array.isArray(warning.applies_to) && warning.applies_to.length) {
+      replacements.scope = warning.applies_to.join(", ");
+    }
+    const text = warning.message_key
+      ? t(warning.message_key, replacements)
+      : "";
+    message.textContent = text || warning.message_key || "";
+    alert.appendChild(message);
+
+    if (warning.documentation_url) {
+      const actions = document.createElement("div");
+      actions.className = "alert__actions";
+      const link = document.createElement("a");
+      link.href = warning.documentation_url;
+      link.target = "_blank";
+      link.rel = "noreferrer noopener";
+      const labelKey = warning.documentation_key || "warnings.learn_more";
+      link.textContent = t(labelKey);
+      actions.appendChild(link);
+      alert.appendChild(actions);
+    }
+
+    yearAlertsContainer.appendChild(alert);
+  });
+
+  yearAlertsContainer.hidden = false;
+}
+
 function applyYearMetadata(year) {
   currentYearMetadata = yearMetadataByYear.get(year) || null;
+  renderYearWarnings(currentYearMetadata);
   populatePayrollSelect(
     employmentPaymentsInput,
     currentYearMetadata?.employment?.payroll || null,
@@ -1352,6 +1489,17 @@ function updateTradeFeeHint() {
         years: tradeFee.newly_self_employed_reduction_years,
       }),
     );
+  }
+
+  if (tradeFee.sunset?.description_key) {
+    const replacements = {};
+    if (tradeFee.sunset.year) {
+      replacements.year = tradeFee.sunset.year;
+    }
+    if (tradeFee.sunset.status_key) {
+      replacements.status = t(tradeFee.sunset.status_key);
+    }
+    messages.push(t(tradeFee.sunset.description_key, replacements));
   }
 
   freelanceTradeFeeHint.textContent = messages.join(" ");

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -199,6 +199,51 @@ header {
   font-weight: 600;
 }
 
+.alert-list {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.alert {
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-left: 0.375rem solid #0d6efd;
+  background: #f1f5ff;
+  color: #084298;
+}
+
+.alert__message {
+  margin: 0;
+}
+
+.alert--warning {
+  border-left-color: #f08c00;
+  background: #fff4e6;
+  color: #7f4a00;
+}
+
+.alert--error {
+  border-left-color: #b02a37;
+  background: #ffe9ec;
+  color: #842029;
+}
+
+.alert__actions {
+  margin-top: 0.5rem;
+}
+
+.alert__actions a {
+  color: #0d6efd;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.alert__actions a:hover,
+.alert__actions a:focus {
+  text-decoration: underline;
+}
+
 .form-control.has-error label {
   color: #b02a37;
 }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -104,13 +104,37 @@
                 />
               </div>
             </div>
+            <div
+              id="year-alerts"
+              class="alert-list"
+              aria-live="polite"
+              hidden
+            ></div>
           </fieldset>
 
           <fieldset class="fieldset">
             <legend data-i18n-key="calculator.legends.employment_pension">
               Employment &amp; pension income
             </legend>
-            <div class="form-grid double">
+            <div class="section-toggle">
+              <input
+                type="checkbox"
+                id="toggle-employment"
+                data-toggle-target="employment-section"
+              />
+              <label
+                for="toggle-employment"
+                data-i18n-key="fields.toggle-employment"
+              >
+                Include salary income
+              </label>
+            </div>
+            <div
+              class="form-grid double"
+              id="employment-section"
+              hidden
+              aria-hidden="true"
+            >
               <div class="form-control">
                 <label
                   for="employment-mode"
@@ -236,6 +260,8 @@
                   value="0"
                 />
               </div>
+            </div>
+            <div class="form-grid double">
               <div class="form-control">
                 <label
                   for="pension-mode"

--- a/src/greektax/backend/app/routes/config.py
+++ b/src/greektax/backend/app/routes/config.py
@@ -14,6 +14,7 @@ from greektax.backend.config.year_config import (
     EFKACategoryConfig,
     PayrollConfig,
     TradeFeeConfig,
+    YearWarning,
     available_years,
     load_year_configuration,
 )
@@ -36,11 +37,20 @@ def _serialise_contributions(contributions: ContributionRates) -> Dict[str, Any]
 
 
 def _serialise_trade_fee(config: TradeFeeConfig) -> Dict[str, Any]:
-    return {
+    payload: Dict[str, Any] = {
         "standard_amount": config.standard_amount,
         "reduced_amount": config.reduced_amount,
         "newly_self_employed_reduction_years": config.newly_self_employed_reduction_years,
     }
+    if config.sunset:
+        payload["sunset"] = {
+            "status_key": config.sunset.status_key,
+            "year": config.sunset.year,
+            "description_key": config.sunset.description_key,
+            "documentation_key": config.sunset.documentation_key,
+            "documentation_url": config.sunset.documentation_url,
+        }
+    return payload
 
 
 def _serialise_efka_categories(
@@ -58,6 +68,17 @@ def _serialise_efka_categories(
             }
         )
     return serialised
+
+
+def _serialise_warning(entry: YearWarning) -> Dict[str, Any]:
+    return {
+        "id": entry.id,
+        "message_key": entry.message_key,
+        "severity": entry.severity,
+        "applies_to": list(entry.applies_to),
+        "documentation_key": entry.documentation_key,
+        "documentation_url": entry.documentation_url,
+    }
 
 
 def _serialise_year(year: int) -> Dict[str, Any]:
@@ -79,6 +100,7 @@ def _serialise_year(year: int) -> Dict[str, Any]:
                 config.freelance.efka_categories
             ),
         },
+        "warnings": [_serialise_warning(entry) for entry in config.warnings],
     }
 
 

--- a/src/greektax/backend/config/data/2024.yaml
+++ b/src/greektax/backend/config/data/2024.yaml
@@ -9,6 +9,7 @@ income:
       allowed_payments_per_year:
         - 14
         - 12
+        - 10
       default_payments_per_year: 14
     contributions:
       employee_rate: 0.1387
@@ -34,6 +35,8 @@ income:
     payroll:
       allowed_payments_per_year:
         - 14
+        - 12
+        - 10
       default_payments_per_year: 14
     contributions:
       employee_rate: 0.0
@@ -63,6 +66,12 @@ income:
       standard_amount: 650
       reduced_amount: 325
       newly_self_employed_reduction_years: 5
+      sunset:
+        status_key: statuses.trade_fee.scheduled
+        year: 2025
+        description_key: hints.freelance-trade-fee-sunset
+        documentation_key: links.trade_fee_sunset
+        documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos
     efka_categories:
       - id: general_a
         label_key: forms.freelance.efka.category.general_a
@@ -219,3 +228,19 @@ deductions:
       validation:
         type: currency
         min: 0
+warnings:
+  - id: employment.partial_year_review
+    severity: warning
+    applies_to:
+      - employment
+      - pension
+    message_key: warnings.employment.partial_year_review
+    documentation_key: warnings.links.partial_year_review
+    documentation_url: https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias
+  - id: freelance.trade_fee_sunset
+    severity: info
+    applies_to:
+      - freelance
+    message_key: warnings.freelance.trade_fee_sunset
+    documentation_key: links.trade_fee_sunset
+    documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos

--- a/src/greektax/backend/config/data/2025.yaml
+++ b/src/greektax/backend/config/data/2025.yaml
@@ -9,6 +9,7 @@ income:
       allowed_payments_per_year:
         - 14
         - 12
+        - 10
       default_payments_per_year: 14
     contributions:
       employee_rate: 0.1387
@@ -34,6 +35,8 @@ income:
     payroll:
       allowed_payments_per_year:
         - 14
+        - 12
+        - 10
       default_payments_per_year: 14
     contributions:
       employee_rate: 0.0
@@ -63,6 +66,12 @@ income:
       standard_amount: 620
       reduced_amount: 310
       newly_self_employed_reduction_years: 5
+      sunset:
+        status_key: statuses.trade_fee.proposed
+        year: 2026
+        description_key: hints.freelance-trade-fee-sunset
+        documentation_key: links.trade_fee_sunset
+        documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos
     efka_categories:
       - id: general_a
         label_key: forms.freelance.efka.category.general_a
@@ -219,3 +228,26 @@ deductions:
       validation:
         type: currency
         min: 0
+warnings:
+  - id: employment.partial_year_review
+    severity: warning
+    applies_to:
+      - employment
+      - pension
+    message_key: warnings.employment.partial_year_review
+    documentation_key: warnings.links.partial_year_review
+    documentation_url: https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias
+  - id: config.pending_deduction_updates
+    severity: warning
+    applies_to:
+      - deductions
+    message_key: warnings.configuration.pending_deductions_2025
+    documentation_key: warnings.links.pending_deductions
+    documentation_url: https://www.aade.gr/polites/eisodima/forologikes-ekptoseis
+  - id: freelance.trade_fee_sunset
+    severity: info
+    applies_to:
+      - freelance
+    message_key: warnings.freelance.trade_fee_sunset
+    documentation_key: links.trade_fee_sunset
+    documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos

--- a/src/greektax/backend/config/validator.py
+++ b/src/greektax/backend/config/validator.py
@@ -1,0 +1,378 @@
+"""Utilities for validating year configuration data and surfacing issues."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from typing import Iterable, Mapping, Sequence
+
+from .year_config import (
+    ContributionRates,
+    DeductionConfig,
+    DeductionHint,
+    EFKACategoryConfig,
+    PayrollConfig,
+    TradeFeeConfig,
+    YearConfiguration,
+    YearWarning,
+    available_years,
+    load_year_configuration,
+)
+
+
+def _format_scope(scope: str, message: str) -> str:
+    return f"{scope}: {message}"
+
+
+def _validate_payroll(scope: str, payroll: PayrollConfig) -> list[str]:
+    errors: list[str] = []
+    allowed = list(payroll.allowed_payments_per_year)
+
+    if not allowed:
+        errors.append(_format_scope(scope, "no allowed payroll frequencies defined"))
+        return errors
+
+    invalid_entries = [value for value in allowed if value <= 0]
+    if invalid_entries:
+        errors.append(
+            _format_scope(
+                scope,
+                "allowed payroll frequencies must be positive integers",
+            )
+        )
+
+    duplicates = [value for value, count in Counter(allowed).items() if count > 1]
+    if duplicates:
+        errors.append(
+            _format_scope(
+                scope,
+                f"duplicate payroll frequency values detected: {sorted(duplicates)}",
+            )
+        )
+
+    if allowed != sorted(allowed):
+        errors.append(
+            _format_scope(scope, "allowed payroll frequencies should be sorted"),
+        )
+
+    default_frequency = payroll.default_payments_per_year
+    if default_frequency not in allowed:
+        errors.append(
+            _format_scope(
+                scope,
+                (
+                    "default payroll frequency "
+                    f"{default_frequency} is not present in the allowed set"
+                ),
+            )
+        )
+
+    return errors
+
+
+def _validate_contributions(scope: str, contributions: ContributionRates) -> list[str]:
+    errors: list[str] = []
+
+    for label, value in {
+        "employee": contributions.employee_rate,
+        "employer": contributions.employer_rate,
+    }.items():
+        if value < 0 or value > 1:
+            errors.append(
+                _format_scope(
+                    scope,
+                    f"{label} contribution rate {value} must be between 0 and 1",
+                )
+            )
+
+    return errors
+
+
+def _validate_trade_fee(trade_fee: TradeFeeConfig) -> list[str]:
+    errors: list[str] = []
+
+    if trade_fee.standard_amount < 0:
+        errors.append(
+            _format_scope("freelance.trade_fee", "standard amount must be non-negative"),
+        )
+
+    reduced = trade_fee.reduced_amount
+    if reduced is not None:
+        if reduced < 0:
+            errors.append(
+                _format_scope(
+                    "freelance.trade_fee",
+                    "reduced amount must be non-negative",
+                )
+            )
+        if reduced > trade_fee.standard_amount:
+            errors.append(
+                _format_scope(
+                    "freelance.trade_fee",
+                    "reduced amount cannot exceed the standard amount",
+                )
+            )
+
+    sunset = trade_fee.sunset
+    if sunset and sunset.documentation_url:
+        if not sunset.documentation_url.startswith(("http://", "https://")):
+            errors.append(
+                _format_scope(
+                    "freelance.trade_fee",
+                    "sunset documentation URL must be absolute",
+                )
+            )
+
+    return errors
+
+
+def _validate_efka_categories(categories: Sequence[EFKACategoryConfig]) -> list[str]:
+    errors: list[str] = []
+
+    seen_ids: set[str] = set()
+    for category in categories:
+        if category.id in seen_ids:
+            errors.append(
+                _format_scope(
+                    "freelance.efka_categories",
+                    f"duplicate category identifier '{category.id}' detected",
+                )
+            )
+        else:
+            seen_ids.add(category.id)
+
+        if category.monthly_amount < 0:
+            errors.append(
+                _format_scope(
+                    "freelance.efka_categories",
+                    f"category '{category.id}' monthly amount must be non-negative",
+                )
+            )
+
+        auxiliary_amount = category.auxiliary_monthly_amount
+        if auxiliary_amount is not None and auxiliary_amount < 0:
+            errors.append(
+                _format_scope(
+                    "freelance.efka_categories",
+                    (
+                        "category "
+                        f"'{category.id}' auxiliary monthly amount must be non-negative"
+                    ),
+                )
+            )
+
+    return errors
+
+
+def _validate_investment_rates(rates: Mapping[str, float]) -> list[str]:
+    errors: list[str] = []
+    for category, rate in rates.items():
+        if rate < 0 or rate > 1:
+            errors.append(
+                _format_scope(
+                    "investment.rates",
+                    f"rate for '{category}' must be between 0 and 1",
+                )
+            )
+    return errors
+
+
+def _validate_deduction_allowances(hint: DeductionHint) -> list[str]:
+    errors: list[str] = []
+    for allowance in hint.allowances:
+        if not allowance.thresholds:
+            errors.append(
+                _format_scope(
+                    f"deductions.{hint.id}",
+                    f"allowance '{allowance.label_key}' must define thresholds",
+                )
+            )
+            continue
+
+        for threshold in allowance.thresholds:
+            if threshold.amount is not None and threshold.amount < 0:
+                errors.append(
+                    _format_scope(
+                        f"deductions.{hint.id}",
+                        (
+                            "threshold "
+                            f"'{threshold.label_key}' amount must be non-negative"
+                        ),
+                    )
+                )
+            if threshold.percentage is not None:
+                if threshold.percentage < 0 or threshold.percentage > 1:
+                    errors.append(
+                        _format_scope(
+                            f"deductions.{hint.id}",
+                            (
+                                "threshold "
+                                f"'{threshold.label_key}' percentage must be between 0 and 1"
+                            ),
+                        )
+                    )
+
+    return errors
+
+
+def _validate_deductions(config: DeductionConfig) -> list[str]:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+
+    for hint in config.hints:
+        if hint.id in seen_ids:
+            errors.append(
+                _format_scope(
+                    "deductions",
+                    f"duplicate hint identifier '{hint.id}' detected",
+                )
+            )
+        else:
+            seen_ids.add(hint.id)
+
+        if "type" not in hint.validation:
+            errors.append(
+                _format_scope(
+                    f"deductions.{hint.id}",
+                    "validation metadata must define a 'type' value",
+                )
+            )
+
+        errors.extend(_validate_deduction_allowances(hint))
+
+    return errors
+
+
+def _validate_warnings(warnings: Iterable[YearWarning]) -> list[str]:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    valid_severities = {"info", "warning", "error"}
+
+    for warning in warnings:
+        if warning.id in seen_ids:
+            errors.append(
+                _format_scope(
+                    "warnings",
+                    f"duplicate warning identifier '{warning.id}' detected",
+                )
+            )
+        else:
+            seen_ids.add(warning.id)
+
+        if warning.severity not in valid_severities:
+            errors.append(
+                _format_scope(
+                    f"warnings.{warning.id}",
+                    f"severity '{warning.severity}' is not recognised",
+                )
+            )
+
+        for target in warning.applies_to:
+            if not target.strip():
+                errors.append(
+                    _format_scope(
+                        f"warnings.{warning.id}",
+                        "applies_to entries must be non-empty strings",
+                    )
+                )
+
+        if warning.documentation_url and not warning.documentation_url.startswith(
+            ("http://", "https://")
+        ):
+            errors.append(
+                _format_scope(
+                    f"warnings.{warning.id}",
+                    "documentation URL must be absolute",
+                )
+            )
+
+    return errors
+
+
+def validate_year_configuration(config: YearConfiguration) -> list[str]:
+    """Return a list of validation issues for the provided configuration."""
+
+    errors: list[str] = []
+
+    errors.extend(_validate_payroll("employment.payroll", config.employment.payroll))
+    errors.extend(_validate_payroll("pension.payroll", config.pension.payroll))
+
+    errors.extend(
+        _validate_contributions("employment.contributions", config.employment.contributions)
+    )
+    errors.extend(
+        _validate_contributions("pension.contributions", config.pension.contributions)
+    )
+
+    errors.extend(_validate_trade_fee(config.freelance.trade_fee))
+    errors.extend(_validate_efka_categories(config.freelance.efka_categories))
+    errors.extend(_validate_investment_rates(config.investment.rates))
+    errors.extend(_validate_deductions(config.deductions))
+    errors.extend(_validate_warnings(config.warnings))
+
+    return errors
+
+
+def validate_all_years(years: Sequence[int] | None = None) -> dict[int, list[str]]:
+    """Validate all configured years and return issues keyed by year."""
+
+    targets = years or available_years()
+    results: dict[int, list[str]] = {}
+
+    for year in targets:
+        config = load_year_configuration(year)
+        results[int(year)] = validate_year_configuration(config)
+
+    return results
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate configured tax years and report issues helpful to contributors."
+        )
+    )
+    parser.add_argument(
+        "years",
+        nargs="*",
+        type=int,
+        help="Specific years to validate (defaults to all configured years)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for running validations from the command line."""
+
+    parser = _build_argument_parser()
+    args = parser.parse_args(argv)
+    years = args.years or available_years()
+
+    if not years:
+        parser.print_help()
+        return 1
+
+    exit_code = 0
+
+    for year in years:
+        try:
+            config = load_year_configuration(year)
+        except FileNotFoundError as error:
+            print(f"[{year}] failed to load configuration: {error}")
+            exit_code = 1
+            continue
+
+        issues = validate_year_configuration(config)
+        if issues:
+            exit_code = 1
+            print(f"[{year}] {len(issues)} issue(s) detected:")
+            for issue in issues:
+                print(f"  - {issue}")
+        else:
+            print(f"[{year}] OK")
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI invocation
+    raise SystemExit(main())

--- a/tests/config/test_validator.py
+++ b/tests/config/test_validator.py
@@ -1,0 +1,35 @@
+from dataclasses import replace
+
+from greektax.backend.config.validator import validate_all_years, validate_year_configuration
+from greektax.backend.config.year_config import load_year_configuration
+
+
+def test_current_configurations_are_valid() -> None:
+    results = validate_all_years()
+    assert all(not issues for issues in results.values()), results
+
+
+def test_validator_flags_invalid_payroll_default() -> None:
+    config = load_year_configuration(2024)
+    employment = replace(
+        config.employment,
+        payroll=replace(config.employment.payroll, default_payments_per_year=99),
+    )
+    broken = replace(config, employment=employment)
+
+    errors = validate_year_configuration(broken)
+
+    assert any("employment.payroll" in error for error in errors)
+
+
+def test_validator_flags_invalid_contribution_rate() -> None:
+    config = load_year_configuration(2024)
+    employment = replace(
+        config.employment,
+        contributions=replace(config.employment.contributions, employee_rate=1.5),
+    )
+    broken = replace(config, employment=employment)
+
+    errors = validate_year_configuration(broken)
+
+    assert any("contributions" in error and "between 0 and 1" in error for error in errors)

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -229,5 +229,85 @@
         }
       }
     }
+  },
+  {
+    "name": "employment_partial_year_payments",
+    "payload": {
+      "year": 2024,
+      "employment": {
+        "gross_income": 18000,
+        "payments_per_year": 10
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 18000.0,
+        "tax_total": 1883.0,
+        "net_income": 13620.4,
+        "average_monthly_tax": 156.92
+      },
+      "details": {
+        "employment": {
+          "payments_per_year": 10,
+          "gross_income_per_payment": 1800.0,
+          "net_income_per_payment": 1362.04,
+          "total_tax": 1883.0
+        }
+      }
+    }
+  },
+  {
+    "name": "freelance_trade_fee_exempt_2025",
+    "payload": {
+      "year": 2025,
+      "freelance": {
+        "gross_revenue": 25000,
+        "deductible_expenses": 6000,
+        "mandatory_contributions": 3200,
+        "include_trade_fee": false
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 19000.0,
+        "tax_total": 2176.0,
+        "net_income": 13624.0,
+        "average_monthly_tax": 181.33
+      },
+      "details": {
+        "freelance": {
+          "taxable_income": 15800.0,
+          "deductible_contributions": 3200.0,
+          "trade_fee": 0.0,
+          "total_tax": 2176.0
+        }
+      }
+    }
+  },
+  {
+    "name": "pension_partial_payment_frequency",
+    "payload": {
+      "year": 2024,
+      "pension": {
+        "gross_income": 12000,
+        "payments_per_year": 12
+      }
+    },
+    "expectations": {
+      "summary": {
+        "income_total": 12000.0,
+        "tax_total": 563.0,
+        "net_income": 11437.0,
+        "average_monthly_tax": 46.92
+      },
+      "details": {
+        "pension": {
+          "payments_per_year": 12,
+          "gross_income_per_payment": 1000.0,
+          "net_income_per_payment": 953.08,
+          "total_tax": 563.0
+        }
+      }
+    }
   }
 ]

--- a/tests/integration/test_config_endpoints.py
+++ b/tests/integration/test_config_endpoints.py
@@ -28,9 +28,17 @@ def test_list_years_endpoint(client: FlaskClient) -> None:
     freelance_meta = current_year["freelance"]
     trade_fee = freelance_meta["trade_fee"]
     assert trade_fee["standard_amount"] > trade_fee.get("reduced_amount", 0)
+    assert "sunset" in trade_fee
+    sunset = trade_fee["sunset"]
+    assert sunset["status_key"].startswith("statuses.trade_fee")
+    assert sunset["documentation_url"].startswith("https://")
     categories = freelance_meta["efka_categories"]
     assert isinstance(categories, list)
     assert any(category["id"] == "general_a" for category in categories)
+
+    warnings = current_year["warnings"]
+    assert isinstance(warnings, list) and warnings
+    assert any(entry["id"] == "config.pending_deduction_updates" for entry in warnings)
 
 
 def test_investment_categories_endpoint(client: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
- surface year-specific alerts in the UI and allow the employment section to be toggled off like other categories
- extend the configuration schema and API to include trade fee sunset metadata and per-year warnings
- expand localisation copy and regression scenarios to cover partial-year payroll and trade-fee exemption cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd560a39d883248faaea1dcf5e84c9