### PR TITLE
Add Sankey visualisation and improve localisation behaviour

### DIFF
--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -198,15 +198,28 @@ deliver user value in incremental, testable slices.
 - Reworked the detail grid layout for consistent label/value pairing and better
   readability on narrow screens.【F:src/frontend/assets/styles/main.css†L400-L432】
 
-## Sprint 16 (Current)
+## Sprint 16 (Completed)
+
+**Highlights**
+- Delivered a Plotly-powered Sankey diagram at the top of the results view so
+  users can immediately see how each income stream divides between taxes,
+  contributions, and take-home pay.
+- Reworked the employment and pension toggle so the entire section now hides in
+  tandem with the checkbox, keeping the form consistent with other optional
+  income categories.
+- Ensured language changes refresh the latest calculation output and year
+  guidance without a full page reload, preserving localisation accuracy during
+  review sessions.
+
+## Sprint 17 (Current)
 
 **Objectives**
 - Integrate the configuration validation tooling into contributor workflows and
   continuous integration to surface actionable feedback early.
 - Refine lightweight, privacy-preserving scenario export concepts that extend
   local persistence without introducing server storage.
-- Plan moderated usability reviews focused on localisation guidance and the
-  refreshed summary layout to drive the next wave of refinements.
+- Plan moderated usability reviews focused on localisation guidance and the new
+  results visualisations to drive the next wave of refinements.
 
 **Planned Deliverables**
 - CI-ready configuration validation checks plus contributor documentation on

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -437,6 +437,28 @@ header {
   color: #495057;
 }
 
+.results-visualisation {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid #e9ecef;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 0.5rem 1.25rem rgba(15, 23, 42, 0.04);
+}
+
+.results-visualisation h4 {
+  margin: 0 0 0.75rem;
+}
+
+.results-visualisation p {
+  margin-top: 0;
+  color: #6c757d;
+}
+
+.sankey-chart {
+  min-height: 320px;
+}
+
 .no-print {
   /* Utility class to hide sections in print layout */
 }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -112,29 +112,29 @@
             ></div>
           </fieldset>
 
-          <fieldset class="fieldset">
+          <div class="section-toggle">
+            <input
+              type="checkbox"
+              id="toggle-employment"
+              data-toggle-target="employment-section"
+            />
+            <label
+              for="toggle-employment"
+              data-i18n-key="fields.toggle-employment"
+            >
+              Include salary income
+            </label>
+          </div>
+          <fieldset
+            class="fieldset"
+            id="employment-section"
+            hidden
+            aria-hidden="true"
+          >
             <legend data-i18n-key="calculator.legends.employment_pension">
               Employment &amp; pension income
             </legend>
-            <div class="section-toggle">
-              <input
-                type="checkbox"
-                id="toggle-employment"
-                data-toggle-target="employment-section"
-              />
-              <label
-                for="toggle-employment"
-                data-i18n-key="fields.toggle-employment"
-              >
-                Include salary income
-              </label>
-            </div>
-            <div
-              class="form-grid double"
-              id="employment-section"
-              hidden
-              aria-hidden="true"
-            >
+            <div class="form-grid double">
               <div class="form-control">
                 <label
                   for="employment-mode"
@@ -879,12 +879,29 @@
 
         <section id="calculation-results" hidden aria-live="polite">
           <h3 data-i18n-key="calculator.results_heading">Results</h3>
+          <div id="sankey-wrapper" class="results-visualisation" hidden>
+            <h4 data-i18n-key="sankey.heading">Income distribution</h4>
+            <p id="sankey-empty" data-i18n-key="sankey.empty">
+              Add taxable income above to see how taxes and net income split
+              across categories.
+            </p>
+            <div
+              id="sankey-chart"
+              class="sankey-chart"
+              role="img"
+              aria-hidden="true"
+            ></div>
+          </div>
           <div class="summary-grid" id="summary-grid"></div>
           <div class="details-list" id="details-list"></div>
         </section>
       </section>
     </main>
 
+    <script
+      src="https://cdn.plot.ly/plotly-2.26.0.min.js"
+      defer
+    ></script>
     <script src="./assets/scripts/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Plotly-powered Sankey diagram ahead of the results grid to visualise income flowing to taxes, contributions, and net pay
- hide the employment and pension fieldset when its toggle is cleared and refresh year guidance/results when the locale changes
- style the new visualisation container and update the project plan for the next sprint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd5f20467083249967243580ec540a