### PR TITLE
Configure backend for Passenger deployment

### DIFF
--- a/src/greektax/backend/passenger_wsgi.py
+++ b/src/greektax/backend/passenger_wsgi.py
@@ -1,6 +1,2 @@
-"""WSGI entrypoint for deploying the GreekTax backend on cPanel."""
-
-from app import create_app
-
-# cPanel's Passenger expects a module-level variable named ``application``.
+from app import create_app  # import the factory from src/greektax/backend/app/__init__.py
 application = create_app()

--- a/src/greektax/backend/requirements.txt
+++ b/src/greektax/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=3.0.0
 PyYAML>=6.0
+plotly>=5.0.0


### PR DESCRIPTION
## Summary
- ensure the backend exposes a Passenger-compatible `application` entrypoint via `passenger_wsgi.py`
- add Plotly to the backend requirements list for deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd82cf93b88324af45bb8f1654cb5a