### PR TITLE
Point frontend API to production backend

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -6,7 +6,7 @@
  * returned by the Flask back-end.
  */
 
-const API_BASE = "/api/v1";
+const API_BASE = "https://cntanos.pythonanywhere.com/api/v1";
 const CALCULATIONS_ENDPOINT = `${API_BASE}/calculations`;
 const CONFIG_YEARS_ENDPOINT = `${API_BASE}/config/years`;
 const CONFIG_INVESTMENT_ENDPOINT = (year, locale) =>


### PR DESCRIPTION
## Summary
- update the frontend API base URL to use the hosted backend instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda2c1888483249985814bed3850df