### PR TITLE
Fix API base detection on custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ for guidance on interpreting the output.
 
 The front-end automatically selects which API base URL to use:
 
-- `https://cntanos.pythonanywhere.com/api/v1` for production-style deployments.
-- `/api/v1` when the calculator is served from a loopback or private network
-  host (e.g. `localhost`, `127.0.0.1`, `192.168.x.x`).
+- `/api/v1` for same-origin deployments (including loopback, private network,
+  or custom domains).
+- `https://cntanos.pythonanywhere.com/api/v1` when hosted directly from the
+  PythonAnywhere environment.
 
 When embedding the calculator in a CMS or iframe, you can override the detected
 endpoint without rebuilding the assets. The lookup order is:

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -100,11 +100,12 @@ const API_BASE = (() => {
     return LOCAL_API_BASE;
   }
 
-  if (normalizedHost.endsWith("pythonanywhere.com")) {
+  const isRemoteHost = normalizedHost.endsWith("pythonanywhere.com");
+  if (isRemoteHost) {
     return REMOTE_API_BASE;
   }
 
-  return REMOTE_API_BASE;
+  return LOCAL_API_BASE;
 })();
 const CALCULATIONS_ENDPOINT = `${API_BASE}/calculations`;
 const CONFIG_YEARS_ENDPOINT = `${API_BASE}/config/years`;


### PR DESCRIPTION
## Summary
- default the frontend API base to the same origin unless hosted on PythonAnywhere
- refresh the configuration docs to describe the new automatic behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb354b8508324899f364364fc275c