### PR TITLE
Improve API base fallback for deployed environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ for guidance on interpreting the output.
 
 The front-end automatically selects which API base URL to use:
 
-- `https://cntanos.pythonanywhere.com/api/v1` for production-style deployments.
-- `/api/v1` when the calculator is served from a loopback or private network
-  host (e.g. `localhost`, `127.0.0.1`, `192.168.x.x`).
+- `/api/v1` for same-origin deployments (including loopback, private network,
+  or custom domains), with an automatic fallback to the remote API if the
+  same-origin endpoint is unreachable.
+- `https://cntanos.pythonanywhere.com/api/v1` when hosted directly from the
+  PythonAnywhere environment or when the local fallback is unavailable.
 
 When embedding the calculator in a CMS or iframe, you can override the detected
 endpoint without rebuilding the assets. The lookup order is:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,27 @@ endpoint without rebuilding the assets. The lookup order is:
 The chosen value is normalised to remove trailing slashes before being used in
 requests.
 
+If you cannot inject the override before the bundle executes, you can adjust
+the API base at runtime by either dispatching an event or calling the exposed
+helper:
+
+```html
+<script>
+  window.dispatchEvent(
+    new CustomEvent("greektax:set-api-base", {
+      detail: { apiBase: "https://example.com/custom/api" },
+    }),
+  );
+
+  // or use the helper attached to the global namespace
+  window.GreekTax?.setApiBase("https://example.com/custom/api");
+  console.log(window.GreekTax?.getApiBase());
+</script>
+```
+
+Both approaches update the active base immediately and store it for subsequent
+requests.
+
 ## Brand & Media Assets
 
 Binary media files are intentionally not stored in this repository. When UI work


### PR DESCRIPTION
## Summary
- add a reusable fetch helper that retries API requests across detected bases until one succeeds
- remember the working API base for subsequent calls and expose it for debugging
- document the automatic fallback behaviour in the configuration guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb354b8508324899f364364fc275c