### PR TITLE
Enable CORS for API endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 authors = [{ name = "GreekTax Contributors" }]
 dependencies = [
     "Flask>=3.0.0",
+    "Flask-Cors>=4.0.0",
     "PyYAML>=6.0",
 ]
 

--- a/src/greektax/backend/app/__init__.py
+++ b/src/greektax/backend/app/__init__.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from flask import Flask, jsonify, send_from_directory
+from flask_cors import CORS
 from werkzeug.exceptions import BadRequest
 
 from .routes import register_routes
@@ -17,6 +18,14 @@ def create_app() -> Flask:
     """Create and configure the Flask application instance."""
 
     app = Flask(__name__)
+
+    CORS(
+        app,
+        resources={r"/api/*": {"origins": "*"}},
+        supports_credentials=False,
+        methods=["GET", "OPTIONS", "POST"],
+        allow_headers=["Content-Type"],
+    )
 
     register_routes(app)
 

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -1,0 +1,31 @@
+"""Integration tests covering CORS behaviour for API endpoints."""
+
+from flask.testing import FlaskClient
+
+
+def test_config_years_endpoint_includes_cors_headers(client: FlaskClient) -> None:
+    """Ensure cross-origin requests are permitted for public configuration data."""
+
+    response = client.get(
+        "/api/v1/config/years",
+        headers={"Origin": "https://example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") == "https://example.com"
+
+
+def test_preflight_request_returns_success(client: FlaskClient) -> None:
+    """Preflight checks should succeed so embedders can call the API."""
+
+    response = client.options(
+        "/api/v1/config/years",
+        headers={
+            "Origin": "https://embedder.test",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") == "https://embedder.test"
+    assert "GET" in response.headers.get("Access-Control-Allow-Methods", "")


### PR DESCRIPTION
## Summary
- add Flask-Cors to the backend dependencies and initialise it for the Flask app
- ensure API responses include permissive CORS headers for cross-origin embeds
- cover the new behaviour with integration tests for standard and preflight requests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb9c9f57c8324b7a85ee22bfabbda