### PR TITLE
Default to remote API for hosted deployments

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -105,6 +105,15 @@ const API_BASE = (() => {
     return REMOTE_API_BASE;
   }
 
+  // When the widget is embedded on a public domain (e.g. WordPress iframe),
+  // there is no same-origin API. Default to the remote API unless we can
+  // confidently detect a local development hostname.
+  const isLikelyHostedEnvironment =
+    Boolean(normalizedHost) && !isLocalHostname && protocol !== "file:";
+  if (isLikelyHostedEnvironment) {
+    return REMOTE_API_BASE;
+  }
+
   return LOCAL_API_BASE;
 })();
 const CALCULATIONS_ENDPOINT = `${API_BASE}/calculations`;


### PR DESCRIPTION
## Summary
- default hosted environments without explicit configuration to the remote API base
- keep local hostnames routed to the local API for development
- document the rationale in code comments

## Testing
- pytest *(fails: missing dependency `flask_cors` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbb283b308324b8eb02b8619ff530