### PR TITLE
Fix Sankey render width measurement on initial load

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -2973,6 +2973,10 @@ function renderCalculation(result) {
     return;
   }
 
+  if (resultsSection) {
+    resultsSection.hidden = false;
+  }
+
   lastCalculation = result;
   downloadButton?.removeAttribute("disabled");
   downloadCsvButton?.removeAttribute("disabled");
@@ -2981,10 +2985,6 @@ function renderCalculation(result) {
   renderSankey(result);
   renderSummary(result.summary || {});
   renderDetails(result.details || []);
-
-  if (resultsSection) {
-    resultsSection.hidden = false;
-  }
 }
 
 function resetResults() {


### PR DESCRIPTION
## Summary
- ensure the results section is unhidden before rendering the Sankey chart so Plotly can size itself to the available width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddbf207bcc8324b6f61eb094d5ecf5