### PR TITLE
Improve numeric input focus and investment breakdown layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,23 @@ be documented in the project plan. Key focus areas for upcoming sprints include:
 Contributions are welcome via pull requests. Please consult the project plan and
 TODO markers across the codebase for the current priorities.
 
+## Versioning
+
+GreekTax tracks releases with the semantic pattern **R.X.Y**:
+
+- **R** – release cycle number signifying major public milestones. This only
+  increments when a full release is declared.
+- **X** – sprint-level increments that bundle new features or significant UI
+  updates. Increase this when a sprint concludes with a packaged deliverable.
+- **Y** – fix iterations for hot-fixes or polish delivered within a sprint.
+  Increment this for follow-up patches within the same sprint.
+
+The current application version is **0.1.0**. When you bump the version, update
+the project metadata, footer copy, and documentation references together so the
+published UI and repository remain in sync.
+
 ## License
 
 GreekTax is released under the [GNU General Public License v3.0](LICENSE).
 
-&copy; 2024 Christos Ntanos for CogniSys. Released under the GNU GPL v3.
+&copy; 2025 Christos Ntanos for CogniSys. Released under the GNU GPL v3 License.

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -57,6 +57,11 @@
   --summary-label: #1f3356;
   --detail-card-bg: rgba(255, 255, 255, 0.96);
   --detail-card-border: rgba(15, 109, 255, 0.14);
+  --breakdown-card-bg: rgba(255, 255, 255, 0.96);
+  --breakdown-card-border: rgba(15, 109, 255, 0.18);
+  --breakdown-label: var(--text-muted);
+  --breakdown-pill-bg: rgba(15, 109, 255, 0.12);
+  --breakdown-pill-text: #0b4aa1;
   --visualisation-border: rgba(15, 109, 255, 0.2);
   --visualisation-bg: linear-gradient(135deg, rgba(15, 109, 255, 0.08), rgba(0, 191, 166, 0.1));
   --tooltip-bg: #07152d;
@@ -123,6 +128,11 @@
   --summary-muted-bg: rgba(10, 28, 51, 0.6);
   --detail-card-bg: rgba(6, 19, 37, 0.94);
   --detail-card-border: rgba(142, 197, 255, 0.26);
+  --breakdown-card-bg: rgba(8, 23, 48, 0.85);
+  --breakdown-card-border: rgba(142, 197, 255, 0.32);
+  --breakdown-label: var(--text-muted);
+  --breakdown-pill-bg: rgba(81, 164, 255, 0.2);
+  --breakdown-pill-text: #d7e6ff;
   --visualisation-border: rgba(142, 197, 255, 0.36);
   --visualisation-bg: linear-gradient(135deg, rgba(40, 123, 255, 0.34), rgba(0, 191, 166, 0.24));
   --tooltip-bg: rgba(2, 8, 18, 0.94);
@@ -740,6 +750,77 @@ main {
   font-weight: 600;
   font-size: 1.05rem;
   text-align: right;
+}
+
+.detail-card dt[data-field="breakdown"],
+.detail-card dd[data-field="breakdown"] {
+  grid-column: 1 / -1;
+}
+
+.detail-card dd[data-field="breakdown"] {
+  text-align: left;
+}
+
+.detail-breakdown {
+  margin-top: 0.35rem;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.detail-breakdown__item {
+  background: var(--breakdown-card-bg);
+  border: 1px solid var(--breakdown-card-border);
+  border-radius: 0.85rem;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 0.9rem 1.6rem rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+:root[data-theme="dark"] .detail-breakdown__item {
+  box-shadow: 0 1.35rem 2.2rem rgba(2, 8, 18, 0.65);
+}
+
+.detail-breakdown__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--breakdown-label);
+}
+
+.detail-breakdown__flow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-body);
+  flex-wrap: wrap;
+}
+
+.detail-breakdown__amount {
+  color: var(--text-body);
+}
+
+.detail-breakdown__arrow {
+  color: var(--text-muted);
+}
+
+.detail-breakdown__tax {
+  color: var(--danger-color);
+}
+
+.detail-breakdown__rate {
+  align-self: flex-start;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--breakdown-pill-bg);
+  color: var(--breakdown-pill-text);
 }
 
 .summary-item dd[data-field="net_income"],

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -982,8 +982,9 @@
 
     <footer class="site-footer">
       <p>
-        &copy; 2024 Christos Ntanos for CogniSys. Released under the GNU GPL v3
-        License.
+        &copy; 2025 Christos Ntanos for CogniSys. Released under the GNU GPL v3
+        License. Version 0.1.0 —
+        <a href="https://github.com/cntanos/greektax">Source on GitHub</a>.
       </p>
     </footer>
 


### PR DESCRIPTION
## Summary
- auto-select numeric calculator inputs on focus so new values overwrite existing amounts immediately
- restyle investment breakdown details with responsive cards, refreshed theme tokens, and highlighted rates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de3e146b9c8324a6f0abe2f2f620ba