### PR TITLE
Fix Sankey responsiveness and bump version to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ GreekTax tracks releases with the semantic pattern **R.X.Y**:
 - **Y** – fix iterations for hot-fixes or polish delivered within a sprint.
   Increment this for follow-up patches within the same sprint.
 
-The current application version is **0.1.0**. When you bump the version, update
+The current application version is **0.1.1**. When you bump the version, update
 the project metadata, footer copy, and documentation references together so the
 published UI and repository remain in sync.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greektax"
-version = "0.1.0"
+version = "0.1.1"
 description = "Unofficial Greek tax estimation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -983,7 +983,7 @@
     <footer class="site-footer">
       <p>
         &copy; 2025 Christos Ntanos for CogniSys. Released under the GNU GPL v3
-        License. Version 0.1.0 —
+        License. Version 0.1.1 —
         <a href="https://github.com/cntanos/greektax">Source on GitHub</a>.
       </p>
     </footer>


### PR DESCRIPTION
## Summary
- add responsive measurement, ResizeObserver support, and layout updates so the Sankey chart fits its container and resizes with the viewport
- bump the application version to 0.1.1 across project metadata and footer copy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de54857aa083248f0063b180477c21