### PR TITLE
Finalize 2025 tax settings and extend agricultural credits

### DIFF
--- a/src/greektax/backend/config/data/2025.yaml
+++ b/src/greektax/backend/config/data/2025.yaml
@@ -1,8 +1,8 @@
 year: 2025
 meta:
   version: 1
-  status: draft
-  notes: "Draft 2025 configuration with updated family tax credits"
+  status: final
+  notes: "Final 2025 configuration with confirmed family credits and trade fee abolition"
 income:
   employment:
     payroll:
@@ -26,7 +26,7 @@ income:
       - rate: 0.44
     tax_credit:
       amounts_by_children:
-        "0": 780
+        "0": 778
         "1": 820
         "2": 910
         "3": 1140
@@ -63,15 +63,9 @@ income:
         rate: 0.36
       - rate: 0.44
     trade_fee:
-      standard_amount: 620
-      reduced_amount: 310
-      newly_self_employed_reduction_years: 5
-      sunset:
-        status_key: statuses.trade_fee.proposed
-        year: 2026
-        description_key: hints.freelance-trade-fee-sunset
-        documentation_key: links.trade_fee_sunset
-        documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos
+      standard_amount: 0
+      reduced_amount: null
+      newly_self_employed_reduction_years: null
     efka_categories:
       - id: general_class_1
         label_key: forms.freelance.efka.category.general_class_1
@@ -284,17 +278,3 @@ warnings:
     message_key: warnings.employment.partial_year_review
     documentation_key: warnings.links.partial_year_review
     documentation_url: https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias
-  - id: config.pending_deduction_updates
-    severity: warning
-    applies_to:
-      - deductions
-    message_key: warnings.configuration.pending_deductions_2025
-    documentation_key: warnings.links.pending_deductions
-    documentation_url: https://www.aade.gr/polites/eisodima/forologikes-ekptoseis
-  - id: freelance.trade_fee_sunset
-    severity: info
-    applies_to:
-      - freelance
-    message_key: warnings.freelance.trade_fee_sunset
-    documentation_key: links.trade_fee_sunset
-    documentation_url: https://www.aade.gr/epiheiriseis/telos-epitidevmatos

--- a/tests/integration/test_config_endpoints.py
+++ b/tests/integration/test_config_endpoints.py
@@ -27,11 +27,9 @@ def test_list_years_endpoint(client: FlaskClient) -> None:
 
     freelance_meta = current_year["freelance"]
     trade_fee = freelance_meta["trade_fee"]
-    assert trade_fee["standard_amount"] > trade_fee.get("reduced_amount", 0)
-    assert "sunset" in trade_fee
-    sunset = trade_fee["sunset"]
-    assert sunset["status_key"].startswith("statuses.trade_fee")
-    assert sunset["documentation_url"].startswith("https://")
+    assert trade_fee["standard_amount"] == 0
+    assert trade_fee.get("reduced_amount") in {None, 0}
+    assert trade_fee.get("sunset") is None
     categories = freelance_meta["efka_categories"]
     assert isinstance(categories, list)
     general_category = next(
@@ -43,7 +41,7 @@ def test_list_years_endpoint(client: FlaskClient) -> None:
 
     warnings = current_year["warnings"]
     assert isinstance(warnings, list) and warnings
-    assert any(entry["id"] == "config.pending_deduction_updates" for entry in warnings)
+    assert all(entry["id"] != "config.pending_deduction_updates" for entry in warnings)
 
 
 def test_investment_categories_endpoint(client: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
- mark the 2025 configuration as final, confirm the family tax credit values, remove the trade fee, and clear pending warnings
- allow agricultural income to receive the employment tax credit when it is the sole taxable source or the filer flags themselves as a professional farmer
- refresh unit and integration coverage for agricultural credits and the 2025 trade fee abolition

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb4263d3083249106e124b38eb562