### PR TITLE
feat: improve responsive calculator layout

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -173,6 +173,12 @@ body {
   color: var(--text-body);
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 .site-header {
   position: relative;
   padding: 3.25rem 1.5rem 4.5rem;
@@ -213,7 +219,8 @@ body {
 
 .site-header__inner {
   margin: 0 auto;
-  max-width: 960px;
+  width: min(92%, 1200px);
+  max-width: 100%;
   display: grid;
   gap: 0.75rem;
   color: var(--hero-text);
@@ -360,7 +367,8 @@ body {
 }
 
 main {
-  max-width: 960px;
+  width: min(92%, 1200px);
+  max-width: 100%;
   margin: -2.5rem auto 3rem;
   display: grid;
   gap: 2.5rem;
@@ -424,9 +432,28 @@ main {
   gap: 1.5rem;
 }
 
+#calculator h2 {
+  margin-bottom: 0.25rem;
+}
+
+.calculator-layout {
+  display: grid;
+  gap: 2rem;
+}
+
 #calculator-form {
   display: grid;
   gap: 1.25rem;
+}
+
+.calculator-results {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-accent);
+  box-shadow: 0 1rem 2.5rem rgba(7, 20, 43, 0.08);
 }
 
 .fieldset {
@@ -1025,14 +1052,162 @@ main {
   /* Utility class to hide sections in print layout */
 }
 
+@media (min-width: 768px) {
+  .site-header {
+    text-align: left;
+    padding: 3.5rem 2.5rem 4.75rem;
+  }
+
+  .site-header__inner {
+    gap: 1.25rem;
+  }
+
+  .site-header__topbar {
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+
+  .preference-bar {
+    margin-left: auto;
+  }
+
+  .intro-highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .card {
+    padding: 2rem;
+  }
+
+  .calculator-results {
+    padding: 1.75rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  main {
+    gap: 3rem;
+    padding: 0 2.5rem 3.5rem;
+  }
+
+  .site-header h1 {
+    font-size: 3rem;
+  }
+
+  .intro-highlights {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .calculator-layout {
+    gap: 2.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .calculator-layout {
+    grid-template-columns: minmax(0, 0.58fr) minmax(320px, 0.42fr);
+    align-items: start;
+  }
+
+  .calculator-results {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .site-header__inner,
+  main {
+    width: min(94%, 1200px);
+  }
+
+  main {
+    gap: 2.25rem;
+    padding: 0 1.75rem 3rem;
+  }
+
+  .calculator-layout {
+    gap: 1.85rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .site-header__inner,
+  main {
+    width: min(96%, 1200px);
+  }
+
+  .site-header__topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .site-branding {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .preference-bar {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .preference-switch {
+    flex: 1;
+    justify-content: space-between;
+  }
+
+  .preference-switch__button {
+    flex: 1;
+  }
+
+  .card {
+    padding: 1.6rem;
+  }
+
+  .calculator-layout {
+    gap: 1.6rem;
+  }
+}
+
 @media (max-width: 640px) {
   body {
     padding: 0;
   }
 
   main {
-    margin: -2rem auto 2rem;
-    padding: 0 1rem 2rem;
+    width: min(98%, 1200px);
+    margin: -2rem auto 2.5rem;
+    padding: 0 1rem 2.5rem;
+  }
+
+  .calculator-layout {
+    gap: 1.5rem;
+  }
+
+  .calculator-results {
+    padding: 1.25rem;
+  }
+
+  .results-visualisation {
+    overflow-x: auto;
+    padding: 1.1rem 1.1rem 1.3rem;
+  }
+
+  .sankey-chart {
+    min-width: 420px;
+  }
+
+  .sankey-legend__item {
+    font-size: 0.85rem;
   }
 
   .form-grid.double {
@@ -1043,12 +1218,31 @@ main {
     grid-template-columns: 1fr;
   }
 
-  .site-title-group {
+  .site-branding {
     flex-direction: column;
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .site-logo {
+    width: 130px;
+  }
+
+  .site-title-group {
+    align-items: flex-start;
   }
 
   .site-header h1 {
-    font-size: 2rem;
+    font-size: 2.1rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions .button {
+    width: 100%;
   }
 
   .intro-highlight {
@@ -1056,8 +1250,34 @@ main {
   }
 }
 
-/* TODO: Implement responsive layout, bilingual typography adjustments, and
-   accessible form styling for the full application UI. */
+@media (max-width: 480px) {
+  .site-header {
+    padding: 2.75rem 1.2rem 3.5rem;
+  }
+
+  .preference-bar {
+    gap: 0.5rem;
+  }
+
+  .preference-switch {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.35rem;
+  }
+
+  .preference-switch__button {
+    font-size: 0.8rem;
+    padding: 0.5rem 0.65rem;
+  }
+
+  .site-header h1 {
+    font-size: 1.9rem;
+  }
+
+  .sankey-chart {
+    min-width: 360px;
+  }
+}
 
 @media print {
   body {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -148,7 +148,8 @@
         <h2 id="calculator-title" data-i18n-key="calculator.heading">
           Tax calculator
         </h2>
-        <form id="calculator-form" novalidate>
+        <div class="calculator-layout">
+          <form id="calculator-form" class="calculator-form" novalidate>
           <p class="form-intro" data-i18n-key="calculator.instructions_intro">
             Toggle the sections that apply, enter your annual or monthly amounts,
             then press calculate to see the breakdown.
@@ -1104,10 +1105,15 @@
               Print summary
             </button>
           </div>
-        <p id="calculator-status" aria-live="polite"></p>
-      </form>
+          <p id="calculator-status" aria-live="polite"></p>
+        </form>
 
-        <section id="calculation-results" hidden aria-live="polite">
+          <section
+            id="calculation-results"
+            class="calculator-results"
+            hidden
+            aria-live="polite"
+          >
           <h3 data-i18n-key="calculator.results_heading">Results</h3>
           <div id="sankey-wrapper" class="results-visualisation" hidden>
             <h4 data-i18n-key="sankey.heading">Income distribution</h4>
@@ -1148,7 +1154,8 @@
           </div>
           <div class="summary-grid" id="summary-grid"></div>
           <div class="details-list" id="details-list"></div>
-        </section>
+          </section>
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- expand the header and main containers to use a fluid width and wrap the calculator form/results in a responsive grid
- add tablet, desktop, and widescreen breakpoints that reposition the results panel alongside the form and tune spacing/typography
- harden the mobile experience by stacking header controls, keeping the form single column, and allowing the Sankey diagram to scroll horizontally when needed

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfb650b0508324b17dc7008683479e