### PR TITLE
Enhance calculator guidance content

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ GreekTax tracks releases with the semantic pattern **R.X.Y**:
 - **Y** – fix iterations for hot-fixes or polish delivered within a sprint.
   Increment this for follow-up patches within the same sprint.
 
-The current application version is **0.1.1**. When you bump the version, update
+The current application version is **0.1.2**. When you bump the version, update
 the project metadata, footer copy, and documentation references together so the
 published UI and repository remain in sync.
 

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -43,7 +43,15 @@ const UI_MESSAGES = {
       tagline: "Unofficial tax estimation toolkit for Greece",
       overview_heading: "Overview",
       overview_description:
-        "Estimate annual income taxes for Greece across employment, freelance, rental, and investment categories. Select a tax year, choose your language, and provide the income figures relevant to your situation to receive a bilingual breakdown of obligations.",
+        "Follow these quick steps to receive a bilingual summary of your Greek income taxes.",
+      overview_step_select_year:
+        "Choose the tax year and confirm the language above.",
+      overview_step_toggle_sections:
+        "Enable the income sections that match your situation.",
+      overview_step_enter_values:
+        "Enter the amounts requested for each active section.",
+      overview_step_calculate:
+        "Press Calculate to view your results and download a copy.",
       disclaimer:
         "Disclaimer: This tool is unofficial and provided as-is. Inputs are stored locally on your device for up to two hours and are never sent to a server. Please consult a professional accountant for formal filings.",
       highlight_inputs_title: "Guided calculator inputs",
@@ -91,8 +99,10 @@ const UI_MESSAGES = {
     calculator: {
       heading: "Tax calculator",
       instructions_intro:
-        "Toggle the sections that apply, enter annual or per-payment figures, then select Calculate to generate your summary.",
+        "Work through the sections you enable, using the hints to enter annual or per-payment figures, then select Calculate to generate your summary.",
       results_heading: "Results",
+      results_intro:
+        "Results Summary: The chart and tables below show your total income, taxes, and net income. Hover over the diagram for details and review each category in the list.",
       legends: {
         year_household: "Year and household",
         employment_pension: "Employment and/or pension income",
@@ -257,6 +267,8 @@ const UI_MESSAGES = {
         "Add EFKA amounts you pay directly with receipts (for example, voluntary top-ups). Leave blank if contributions are only withheld from payslips.",
       "employment-withholding":
         "Enter PAYE income tax already withheld on your payslips to reduce the balance due.",
+      "year-partial-note":
+        "If you didn't earn income for the full year, enter what you earned; the annual tax credit still applies in full.",
       "employment-net-note":
         "Net-to-gross salary conversion isn't supported. Choose annual or per-payment mode above and provide gross amounts only.",
       "employment-income":
@@ -287,7 +299,7 @@ const UI_MESSAGES = {
       "freelance-expenses":
         "Claim only expenses backed by invoices (rent, utilities, professional fees, equipment, vehicle costs used for business).",
       "freelance-trade-fee-location":
-        "Standard: full fee; Reduced: half fee for eligible small towns/islands.",
+        "Standard areas pay the full business activity fee; reduced areas pay half in eligible small towns or islands.",
       "freelance-activity-start-year":
         "Determines if the new-business 5-year fee exemption applies.",
       "freelance-trade-fee": "Trade fee applied: {{amount}}.",
@@ -297,7 +309,9 @@ const UI_MESSAGES = {
       "freelance-trade-fee-new-expired":
         "The reduced-rate window has ended (more than {{years}} years of activity).",
       "freelance-trade-fee-sunset":
-        "The trade fee is scheduled to change from {{year}} (status: {{status}}). Confirm any exemptions with your accountant.",
+        "The business activity fee is slated to return from {{year}} (status: {{status}}). Double-check the latest rules with your accountant.",
+      "freelance-trade-fee-waived":
+        "No business activity fee is due for this tax year, so you can leave this switched off.",
     },
     warnings: {
       learn_more: "Learn more",
@@ -307,7 +321,7 @@ const UI_MESSAGES = {
       },
       freelance: {
         trade_fee_sunset:
-          "Legislated trade-fee changes are pending final confirmation. Verify whether the business activity fee applies for {{year}} before filing.",
+          "AADE plans to bring back the business activity fee in stages. For {{year}}, confirm whether it applies to your activity before you submit.",
       },
       configuration: {
         pending_deductions_2025:
@@ -339,7 +353,15 @@ const UI_MESSAGES = {
       tagline: "Μη επίσημο εργαλείο εκτίμησης φόρων για την Ελλάδα",
       overview_heading: "Επισκόπηση",
       overview_description:
-        "Υπολογίστε ετήσιες φορολογικές υποχρεώσεις στην Ελλάδα για μισθωτούς, ελεύθερους επαγγελματίες, ενοίκια και επενδύσεις. Επιλέξτε φορολογικό έτος, γλώσσα και εισάγετε τα ποσά για να λάβετε δίγλωσση ανάλυση.",
+        "Ακολουθήστε αυτά τα σύντομα βήματα για να λάβετε δίγλωσση σύνοψη των ελληνικών φορολογικών σας υποχρεώσεων.",
+      overview_step_select_year:
+        "Επιλέξτε το φορολογικό έτος και επιβεβαιώστε τη γλώσσα παραπάνω.",
+      overview_step_toggle_sections:
+        "Ενεργοποιήστε τις ενότητες εισοδήματος που ταιριάζουν στην περίπτωσή σας.",
+      overview_step_enter_values:
+        "Καταχωρήστε τα ζητούμενα ποσά για κάθε ενεργή ενότητα.",
+      overview_step_calculate:
+        "Πατήστε Υπολογισμός για να δείτε τα αποτελέσματα και να κατεβάσετε αντίγραφο.",
       disclaimer:
         "Αποποίηση ευθύνης: Το εργαλείο είναι ανεπίσημο και παρέχεται ως έχει. Τα δεδομένα εισόδου αποθηκεύονται τοπικά στη συσκευή σας για έως δύο ώρες και δεν αποστέλλονται σε διακομιστή. Συμβουλευτείτε λογιστή για επίσημες δηλώσεις.",
       highlight_inputs_title: "Καθοδηγούμενη εισαγωγή στοιχείων",
@@ -387,8 +409,10 @@ const UI_MESSAGES = {
     calculator: {
       heading: "Φορολογικός υπολογιστής",
       instructions_intro:
-        "Ενεργοποιήστε τις ενότητες που σας αφορούν, εισάγετε ετήσια ή ανά πληρωμή ποσά και πατήστε Υπολογισμός για να δείτε την ανάλυση.",
+        "Εργαστείτε στις ενότητες που ενεργοποιείτε, χρησιμοποιώντας τις συμβουλές για να εισάγετε ετήσια ή ανά πληρωμή ποσά και πατήστε Υπολογισμός για να δημιουργηθεί η σύνοψη.",
       results_heading: "Αποτελέσματα",
+      results_intro:
+        "Σύνοψη αποτελεσμάτων: Το διάγραμμα και οι πίνακες που ακολουθούν δείχνουν το συνολικό εισόδημα, τους φόρους και το καθαρό ποσό. Τοποθετήστε τον δείκτη πάνω από το διάγραμμα για λεπτομέρειες και δείτε την ανάλυση κάθε κατηγορίας στη λίστα.",
       legends: {
         year_household: "Έτος και νοικοκυριό",
         employment_pension: "Εισόδημα από μισθωτή εργασία ή/και συντάξεις",
@@ -554,6 +578,8 @@ const UI_MESSAGES = {
         "Προσθέστε εισφορές ΕΦΚΑ που καταβάλλετε απευθείας με αποδείξεις (π.χ. προαιρετικές συμπληρωματικές). Αφήστε κενό αν οι εισφορές παρακρατούνται μόνο μέσω μισθοδοσίας.",
       "employment-withholding":
         "Καταχωρήστε τον φόρο PAYE που έχει ήδη παρακρατηθεί στις μισθοδοσίες ώστε να μειωθεί το υπόλοιπο.",
+      "year-partial-note":
+        "Αν δεν είχατε εισόδημα για ολόκληρο το έτος, καταχωρήστε ό,τι εισπράξατε· η ετήσια φορολογική πίστωση εφαρμόζεται κανονικά.",
       "employment-net-note":
         "Δεν υποστηρίζεται μετατροπή καθαρού μισθού σε ακαθάριστο. Επιλέξτε ετήσια ή ανά καταβολή εισαγωγή και συμπληρώστε μόνο ακαθάριστα ποσά.",
       "employment-income":
@@ -584,7 +610,7 @@ const UI_MESSAGES = {
       "freelance-expenses":
         "Καταχωρήστε μόνο δαπάνες με νόμιμα παραστατικά (ενοίκιο, ΔΕΚΟ, επαγγελματικές αμοιβές, εξοπλισμός, επαγγελματική χρήση οχήματος).",
       "freelance-trade-fee-location":
-        "Τυπικό: πλήρες τέλος· Μειωμένο: μισό τέλος για επιλέξιμες μικρές πόλεις/νησιά.",
+        "Στις τυπικές περιοχές εφαρμόζεται ολόκληρο το τέλος επιτηδεύματος· στις μειωμένες περιοχές (μικρές πόλεις/νησιά) εφαρμόζεται το μισό.",
       "freelance-activity-start-year":
         "Καθορίζει αν ισχύει η 5ετής απαλλαγή νέας επιχείρησης.",
       "freelance-trade-fee": "Εφαρμοζόμενο τέλος επιτηδεύματος: {{amount}}.",
@@ -594,7 +620,9 @@ const UI_MESSAGES = {
       "freelance-trade-fee-new-expired":
         "Το παράθυρο μειωμένης χρέωσης έχει λήξει (πάνω από {{years}} έτη δραστηριότητας).",
       "freelance-trade-fee-sunset":
-        "Το τέλος επιτηδεύματος αναμένεται να αλλάξει από {{year}} (κατάσταση: {{status}}). Επιβεβαιώστε τυχόν απαλλαγές με τον λογιστή σας.",
+        "Το τέλος επιτηδεύματος αναμένεται να επανέλθει από το {{year}} (κατάσταση: {{status}}). Επιβεβαιώστε τις τρέχουσες οδηγίες με τον λογιστή σας.",
+      "freelance-trade-fee-waived":
+        "Για το συγκεκριμένο φορολογικό έτος δεν οφείλεται τέλος επιτηδεύματος, επομένως αφήστε τον διακόπτη απενεργοποιημένο.",
     },
     warnings: {
       learn_more: "Μάθετε περισσότερα",
@@ -604,7 +632,7 @@ const UI_MESSAGES = {
       },
       freelance: {
         trade_fee_sunset:
-          "Οι αλλαγές στο τέλος επιτηδεύματος εκκρεμούν για οριστικοποίηση. Βεβαιωθείτε ότι ισχύει για το {{year}} πριν από την υποβολή.",
+          "Η ΑΑΔΕ σχεδιάζει την επαναφορά του τέλους επιτηδεύματος σταδιακά. Για το {{year}} επιβεβαιώστε αν ισχύει για τη δραστηριότητά σας πριν από την υποβολή.",
       },
       configuration: {
         pending_deductions_2025:
@@ -2275,9 +2303,13 @@ function updateTradeFeeHint() {
   }
 
   if (typeof amount === "number" && Number.isFinite(amount)) {
-    messages.push(
-      t("hints.freelance-trade-fee", { amount: formatCurrency(amount) }),
-    );
+    if (amount > 0) {
+      messages.push(
+        t("hints.freelance-trade-fee", { amount: formatCurrency(amount) }),
+      );
+    } else if (amount === 0) {
+      messages.push(t("hints.freelance-trade-fee-waived"));
+    }
   }
 
   if (tradeFee.newly_self_employed_reduction_years) {

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -399,6 +399,17 @@ main {
   margin-bottom: 0.75rem;
 }
 
+.overview-steps {
+  margin: 0 0 1.5rem 1.25rem;
+  padding: 0;
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+}
+
+.overview-steps li {
+  margin: 0 0 0.35rem;
+}
+
 .intro-highlights {
   display: grid;
   gap: 0.85rem;
@@ -434,6 +445,12 @@ main {
 
 #calculator h2 {
   margin-bottom: 0.25rem;
+}
+
+.results-intro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
 }
 
 .calculator-layout {
@@ -511,6 +528,11 @@ main {
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
+}
+
+.form-hint--note {
+  margin-top: 0.25rem;
+  font-style: italic;
 }
 
 .help-panel {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -84,11 +84,23 @@
       <section id="app-intro" class="card">
         <h2 data-i18n-key="ui.overview_heading">Overview</h2>
         <p data-i18n-key="ui.overview_description">
-          Estimate annual income taxes for Greece across employment, freelance,
-          rental, and investment categories. Select a tax year, choose your
-          language, and provide the income figures relevant to your situation to
-          receive a bilingual breakdown of obligations.
+          Follow these quick steps to receive a bilingual summary of your Greek
+          income taxes.
         </p>
+        <ol class="overview-steps">
+          <li data-i18n-key="ui.overview_step_select_year">
+            Choose the tax year and confirm the language above.
+          </li>
+          <li data-i18n-key="ui.overview_step_toggle_sections">
+            Enable the income sections that match your situation.
+          </li>
+          <li data-i18n-key="ui.overview_step_enter_values">
+            Enter the amounts requested for each active section.
+          </li>
+          <li data-i18n-key="ui.overview_step_calculate">
+            Press Calculate to view your results and download a copy.
+          </li>
+        </ol>
         <ul class="intro-highlights">
           <li class="intro-highlight">
             <p
@@ -167,6 +179,14 @@
                   Tax year
                 </label>
                 <select id="year-select" name="year"></select>
+                <p
+                  id="year-partial-note"
+                  class="form-hint form-hint--note"
+                  data-i18n-key="hints.year-partial-note"
+                >
+                  If you did not earn income for the full year, enter what you
+                  received—the full-year tax credit still applies.
+                </p>
               </div>
               <div class="form-control">
                 <label
@@ -1162,6 +1182,11 @@
             aria-live="polite"
           >
           <h3 data-i18n-key="calculator.results_heading">Results</h3>
+          <p class="results-intro" data-i18n-key="calculator.results_intro">
+            Results Summary: The chart and tables below show your total income,
+            taxes, and net income. Hover over the diagram for details and review
+            each category in the list.
+          </p>
           <div id="sankey-wrapper" class="results-visualisation" hidden>
             <h4 data-i18n-key="sankey.heading">Income distribution</h4>
             <div class="sankey-legend" role="list">
@@ -1209,7 +1234,8 @@
     <footer class="site-footer">
       <p>
         &copy; 2025 Christos Ntanos for CogniSys. Released under the GNU GPL v3
-        License. Version 0.1.1 —
+        License. Version 0.1.2 —
+        <!-- R is the release, X is a major revision, Y is a minor revision -->
         <a href="https://github.com/cntanos/greektax">Source on GitHub</a>.
       </p>
     </footer>


### PR DESCRIPTION
## Summary
- replace the overview copy with a four-step quick guide and add a results summary introduction for the calculator
- surface a partial-year income hint under the tax year selector and clarify trade fee guidance, including the waiver message and updated alerts in both languages
- add styling for the new notes and bump the documented version to 0.1.2 for the next R.X.Y minor revision

## Testing
- not run (static front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68dfbe77b5a48324b3b474a66657881c