### PR TITLE
chore: bump major revision to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ GreekTax tracks releases with the semantic pattern **R.X.Y**:
 - **Y** – fix iterations for hot-fixes or polish delivered within a sprint.
   Increment this for follow-up patches within the same sprint.
 
+The current milestone is **R.5.0** (version `0.5.0` in `pyproject.toml`),
+reflecting the fifth major sprint within the initial release cycle.
+
 The canonical version is declared once in [`pyproject.toml`](pyproject.toml) and
 is surfaced automatically via the `/api/v1/config/meta` endpoint and the UI
 footer. Bump the value there to propagate the new release identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greektax"
-version = "0.4.0"
+version = "0.5.0"
 description = "Unofficial Greek tax estimation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- update the project version to 0.5.0 to reflect the next major sprint within release cycle R
- document the current milestone R.5.0 in the README versioning guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff5117e408324b31878050cb78114