### PR TITLE
Improve responsive results layout and pie chart

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -222,7 +222,7 @@ body {
 
 .site-header__inner {
   margin: 0 auto;
-  width: min(92%, 1440px);
+  width: clamp(18rem, 92vw, 2560px);
   max-width: 100%;
   display: grid;
   gap: 0.75rem;
@@ -371,7 +371,7 @@ body {
 }
 
 main {
-  width: min(90%, 1400px);
+  width: clamp(20rem, 92vw, 2560px);
   max-width: 100%;
   margin: -2.5rem auto 2.25rem;
   display: grid;
@@ -1061,9 +1061,52 @@ main {
 }
 
 .distribution-empty {
-  margin: 0;
+  margin: 0 0 0.5rem;
   color: var(--text-subtle);
   font-size: 0.9rem;
+}
+
+.distribution-visual {
+  display: grid;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.distribution-chart {
+  width: min(100%, 320px);
+  aspect-ratio: 1 / 1;
+  align-self: center;
+  justify-self: center;
+}
+
+.distribution-chart__ring {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.3);
+  stroke-width: 32;
+}
+
+:root[data-theme="dark"] .distribution-chart__ring {
+  stroke: rgba(3, 19, 23, 0.65);
+}
+
+.distribution-chart__segment {
+  fill: none;
+  stroke-width: 32;
+  stroke-linecap: butt;
+  transition: stroke-dashoffset 0.35s ease, stroke 0.35s ease;
+}
+
+.distribution-chart__center-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  fill: var(--text-muted);
+}
+
+.distribution-chart__center-value {
+  font-weight: 700;
+  font-size: 1.1rem;
+  fill: var(--text-body);
 }
 
 .distribution-list {
@@ -1074,73 +1117,49 @@ main {
   gap: 0.75rem;
 }
 
-.distribution-row {
+.distribution-legend__item {
   display: grid;
-  gap: 0.45rem;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(15, 109, 255, 0.08);
 }
 
-.distribution-row__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.75rem;
+:root[data-theme="dark"] .distribution-legend__item {
+  background: rgba(3, 19, 23, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(50, 224, 212, 0.22);
 }
 
-.distribution-row__label {
+.distribution-legend__swatch {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+  background: var(--distribution-color, var(--flow-net));
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.6);
+}
+
+:root[data-theme="dark"] .distribution-legend__swatch {
+  box-shadow: 0 0 0 2px rgba(3, 19, 23, 0.75);
+}
+
+.distribution-legend__label {
   font-weight: 600;
 }
 
-.distribution-row__amount {
+.distribution-legend__amount {
   font-variant-numeric: tabular-nums;
   color: var(--text-subtle);
+  justify-self: end;
 }
 
-.distribution-row__bar {
-  position: relative;
-  height: 0.6rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.25);
-  overflow: hidden;
-}
-
-:root[data-theme="dark"] .distribution-row__bar {
-  background: rgba(3, 19, 23, 0.75);
-}
-
-.distribution-row__fill {
-  position: absolute;
-  inset: 0;
-  transform-origin: left center;
-  width: calc(var(--distribution-ratio, 0) * 100%);
-  background: var(--distribution-color, var(--flow-net));
-  border-radius: inherit;
-  transition: width 0.25s ease;
-}
-
-.distribution-row__percent {
-  position: absolute;
-  right: 0.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 0.8rem;
+.distribution-legend__percent {
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.92);
-}
-
-:root[data-theme="dark"] .distribution-row__percent {
   color: var(--text-body);
-}
-
-.distribution-row[data-category="taxes"] .distribution-row__fill {
-  background: var(--flow-taxes);
-}
-
-.distribution-row[data-category="insurance"] .distribution-row__fill {
-  background: var(--flow-contributions);
-}
-
-.distribution-row[data-category="expenses"] .distribution-row__fill {
-  background: var(--flow-expenses);
+  justify-self: end;
 }
 
 .sankey-legend {
@@ -1215,6 +1234,14 @@ main {
   .calculator-results {
     padding: 1.6rem;
   }
+
+  .distribution-visual {
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+  }
+
+  .distribution-chart {
+    width: min(100%, 360px);
+  }
 }
 
 @media (min-width: 1024px) {
@@ -1234,11 +1261,15 @@ main {
   .calculator-layout {
     gap: 2rem;
   }
+
+  .distribution-chart {
+    width: min(100%, 380px);
+  }
 }
 
 @media (min-width: 1340px) {
   .calculator-layout {
-    grid-template-columns: minmax(0, 0.68fr) minmax(340px, 0.32fr);
+    grid-template-columns: minmax(0, 0.68fr) minmax(380px, 0.32fr);
     align-items: start;
   }
 
@@ -1250,14 +1281,47 @@ main {
 
 @media (min-width: 1600px) {
   .calculator-layout {
-    grid-template-columns: minmax(0, 0.7fr) minmax(360px, 0.3fr);
+    grid-template-columns: minmax(0, 0.7fr) minmax(420px, 0.3fr);
+  }
+}
+
+@media (min-width: 1920px) {
+  .calculator-layout {
+    grid-template-columns: minmax(0, 0.72fr) minmax(460px, 0.28fr);
+    gap: 2.35rem;
+  }
+
+  .distribution-chart {
+    width: min(100%, 420px);
+  }
+}
+
+@media (min-width: 2200px) {
+  .calculator-layout {
+    grid-template-columns: minmax(0, 0.74fr) minmax(520px, 0.26fr);
+    gap: 2.5rem;
+  }
+
+  .distribution-chart {
+    width: min(100%, 460px);
+  }
+}
+
+@media (min-width: 2560px) {
+  .calculator-layout {
+    grid-template-columns: minmax(0, 0.76fr) minmax(560px, 0.24fr);
+    gap: 2.75rem;
+  }
+
+  .distribution-chart {
+    width: min(100%, 480px);
   }
 }
 
 @media (max-width: 1024px) {
   .site-header__inner,
   main {
-    width: min(94%, 1440px);
+    width: clamp(20rem, 94vw, 2560px);
   }
 
   main {
@@ -1277,7 +1341,7 @@ main {
 
   .site-header__inner,
   main {
-    width: min(96%, 1440px);
+    width: clamp(20rem, 96vw, 2560px);
   }
 
   .site-header__topbar {
@@ -1324,7 +1388,7 @@ main {
   }
 
   main {
-    width: min(98%, 1440px);
+    width: clamp(20rem, 98vw, 2560px);
     margin: -2rem auto 2.5rem;
     padding: 0 1rem 2.5rem;
   }
@@ -1418,6 +1482,21 @@ main {
   .preference-switch__button {
     font-size: 0.76rem;
     padding: 0.4rem 0.6rem;
+  }
+
+  .distribution-visual {
+    justify-items: center;
+  }
+
+  .distribution-legend__item {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    row-gap: 0.35rem;
+  }
+
+  .distribution-legend__amount,
+  .distribution-legend__percent {
+    justify-self: start;
   }
 
   .site-header h1 {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1243,11 +1243,20 @@
               Add taxable income above to reveal the allocation across all
               categories.
             </p>
-            <ul
-              id="distribution-list"
-              class="distribution-list"
-              role="list"
-            ></ul>
+            <div class="distribution-visual">
+              <svg
+                id="distribution-chart"
+                class="distribution-chart"
+                viewBox="0 0 240 240"
+                role="img"
+                aria-hidden="true"
+              ></svg>
+              <ul
+                id="distribution-list"
+                class="distribution-list"
+                role="list"
+              ></ul>
+            </div>
           </div>
           <div class="summary-grid" id="summary-grid"></div>
           <div class="details-list" id="details-list"></div>


### PR DESCRIPTION
## Summary
- expand the calculator layout to support larger breakpoints and keep the results column side-by-side only when wide enough for the Sankey chart
- restyle the distribution card with a responsive pie chart and legend that adapts to light/dark themes
- tidy up result resets so the distribution visual hides and shows correctly when calculations change

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e00700fb1c8324bb9d19929c140622