### PR TITLE
Ensure calculator results stack below inputs

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -460,6 +460,7 @@ main {
 .calculator-layout {
   display: grid;
   gap: 1.75rem;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 #calculator-form {
@@ -1269,50 +1270,27 @@ main {
 
 @media (min-width: 1340px) {
   .calculator-layout {
-    grid-template-columns: minmax(0, 0.68fr) minmax(380px, 0.32fr);
     align-items: start;
   }
 
   .calculator-results {
-    position: sticky;
-    top: 1.5rem;
-  }
-}
-
-@media (min-width: 1600px) {
-  .calculator-layout {
-    grid-template-columns: minmax(0, 0.7fr) minmax(420px, 0.3fr);
+    position: static;
   }
 }
 
 @media (min-width: 1920px) {
-  .calculator-layout {
-    grid-template-columns: minmax(0, 0.72fr) minmax(460px, 0.28fr);
-    gap: 2.35rem;
-  }
-
   .distribution-chart {
     width: min(100%, 420px);
   }
 }
 
 @media (min-width: 2200px) {
-  .calculator-layout {
-    grid-template-columns: minmax(0, 0.74fr) minmax(520px, 0.26fr);
-    gap: 2.5rem;
-  }
-
   .distribution-chart {
     width: min(100%, 460px);
   }
 }
 
 @media (min-width: 2560px) {
-  .calculator-layout {
-    grid-template-columns: minmax(0, 0.76fr) minmax(560px, 0.24fr);
-    gap: 2.75rem;
-  }
-
   .distribution-chart {
     width: min(100%, 480px);
   }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -679,6 +679,7 @@
                   min="1900"
                   max="2100"
                   step="1"
+                  value="2000"
                 />
                 <p
                   class="form-hint"


### PR DESCRIPTION
## Summary
- keep the calculator results stacked below the form on all screen sizes by removing the wide-screen two-column layout
- default the freelance activity start year field to 2000 for new sessions

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e011ddc3b48324b437c0442860b8ec