### PR TITLE
Improve numeric input handling and add clear form control

### DIFF
--- a/src/frontend/assets/scripts/translations.generated.js
+++ b/src/frontend/assets/scripts/translations.generated.js
@@ -5,6 +5,7 @@
     "el": {
       "actions": {
         "calculate": "Υπολογισμός φόρων",
+        "clear": "Καθαρισμός φόρμας",
         "download": "Λήψη σύνοψης (JSON)",
         "download_csv": "Λήψη σύνοψης (CSV)",
         "print": "Εκτύπωση σύνοψης"
@@ -282,6 +283,7 @@
     "en": {
       "actions": {
         "calculate": "Calculate taxes",
+        "clear": "Clear form",
         "download": "Download summary (JSON)",
         "download_csv": "Download summary (CSV)",
         "print": "Print summary"

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -804,9 +804,25 @@ main {
   font-size: 1rem;
   width: 100%;
   max-width: 100%;
+  background-color: var(--surface-raised);
+  box-shadow: 0 0.75rem 1.6rem rgba(15, 109, 255, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease, transform 0.2s ease;
+  color: var(--text-body);
 }
 
-.form-control input[type="number"] {
+.form-control input {
+  appearance: none;
+}
+
+.form-control input[data-numeric-input] {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  letter-spacing: 0.01em;
+}
+
+.form-control input[data-numeric-input]:focus {
   text-align: right;
 }
 
@@ -814,6 +830,8 @@ main {
 .form-control select:focus {
   outline: 2px solid var(--field-focus);
   outline-offset: 2px;
+  border-color: var(--field-focus);
+  box-shadow: 0 1rem 2rem rgba(15, 109, 255, 0.16);
 }
 
 .inline-field {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -200,7 +200,10 @@
                 <input
                   id="children-input"
                   name="dependents.children"
-                  type="number"
+                  type="text"
+                  inputmode="numeric"
+                  data-numeric-input
+                  data-precision="0"
                   min="0"
                   step="1"
                   value="0"
@@ -415,7 +418,10 @@
                     <input
                       id="employment-employee-contributions"
                       name="employment.employee_contributions"
-                      type="number"
+                      type="text"
+                      inputmode="decimal"
+                      data-numeric-input
+                      data-precision="2"
                       min="0"
                       step="0.01"
                       value="0"
@@ -442,7 +448,10 @@
                 <input
                   id="employment-withholding"
                   name="withholding_tax"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -472,7 +481,10 @@
                 <input
                   id="employment-income"
                   name="employment.gross_income"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -502,7 +514,10 @@
                 <input
                   id="employment-monthly-income"
                   name="employment.monthly_income"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -588,7 +603,10 @@
                   <input
                     id="pension-income"
                     name="pension.gross_income"
-                    type="number"
+                    type="text"
+                    inputmode="decimal"
+                    data-numeric-input
+                    data-precision="2"
                     min="0"
                     step="0.01"
                     value="0"
@@ -652,7 +670,10 @@
                   <input
                     id="pension-net-income"
                     name="pension.net_income"
-                    type="number"
+                    type="text"
+                    inputmode="decimal"
+                    data-numeric-input
+                    data-precision="2"
                     min="0"
                     step="0.01"
                     value="0"
@@ -683,7 +704,10 @@
                   <input
                     id="pension-net-monthly-income"
                     name="pension.net_monthly_income"
-                    type="number"
+                    type="text"
+                    inputmode="decimal"
+                    data-numeric-input
+                    data-precision="2"
                     min="0"
                     step="0.01"
                     value="0"
@@ -731,7 +755,10 @@
                 <input
                   id="freelance-revenue"
                   name="freelance.gross_revenue"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -755,7 +782,10 @@
                 <input
                   id="freelance-expenses"
                   name="freelance.deductible_expenses"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -796,7 +826,10 @@
                 <input
                   id="freelance-efka-months"
                   name="freelance.efka_months"
-                  type="number"
+                  type="text"
+                  inputmode="numeric"
+                  data-numeric-input
+                  data-precision="0"
                   min="0"
                   max="24"
                   step="1"
@@ -812,7 +845,10 @@
                 </label>
                 <input
                   id="freelance-activity-start-year"
-                  type="number"
+                  type="text"
+                  inputmode="numeric"
+                  data-numeric-input
+                  data-precision="0"
                   min="1900"
                   max="2100"
                   step="1"
@@ -880,7 +916,10 @@
                     <input
                       id="freelance-contributions"
                       name="freelance.mandatory_contributions"
-                      type="number"
+                      type="text"
+                      inputmode="decimal"
+                      data-numeric-input
+                      data-precision="2"
                       min="0"
                       step="0.01"
                       value="0"
@@ -896,7 +935,10 @@
                     <input
                       id="freelance-auxiliary-contributions"
                       name="freelance.auxiliary_contributions"
-                      type="number"
+                      type="text"
+                      inputmode="decimal"
+                      data-numeric-input
+                      data-precision="2"
                       min="0"
                       step="0.01"
                       value="0"
@@ -912,7 +954,10 @@
                     <input
                       id="freelance-lump-sum-contributions"
                       name="freelance.lump_sum_contributions"
-                      type="number"
+                      type="text"
+                      inputmode="decimal"
+                      data-numeric-input
+                      data-precision="2"
                       min="0"
                       step="0.01"
                       value="0"
@@ -974,7 +1019,10 @@
                 <input
                   id="agricultural-revenue"
                   name="agricultural.gross_revenue"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -990,7 +1038,10 @@
                 <input
                   id="agricultural-expenses"
                   name="agricultural.deductible_expenses"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1038,7 +1089,10 @@
                 <input
                   id="other-income"
                   name="other.taxable_income"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1071,7 +1125,10 @@
                 <input
                   id="rental-income"
                   name="rental.gross_income"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1087,7 +1144,10 @@
                 <input
                   id="rental-expenses"
                   name="rental.deductible_expenses"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1132,7 +1192,10 @@
                 <input
                   id="deductions-donations"
                   name="deductions.donations"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1148,7 +1211,10 @@
                 <input
                   id="deductions-medical"
                   name="deductions.medical"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1164,7 +1230,10 @@
                 <input
                   id="deductions-education"
                   name="deductions.education"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1180,7 +1249,10 @@
                 <input
                   id="deductions-insurance"
                   name="deductions.insurance"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1201,7 +1273,10 @@
                 <input
                   id="enfia-due"
                   name="obligations.enfia"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1214,7 +1289,10 @@
                 <input
                   id="luxury-due"
                   name="obligations.luxury"
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
+                  data-numeric-input
+                  data-precision="2"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1231,6 +1309,14 @@
               data-i18n-key="actions.calculate"
             >
               Calculate taxes
+            </button>
+            <button
+              type="button"
+              class="button secondary"
+              id="clear-button"
+              data-i18n-key="actions.clear"
+            >
+              Clear form
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- replace numeric calculator inputs with locale-formatted text fields and ensure state persistence uses normalized values
- modernise calculator input styling and add a clear button with supporting localisation
- tighten Sankey hover output to show only labels and keep numeric formatting in sync with locale changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e276e1e92883249e65ba7f672ca69a