### PR TITLE
Guard calculator state parsing against malformed data

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -635,6 +635,11 @@ function loadStoredCalculatorState() {
       return null;
     }
 
+    if (typeof raw !== "string" || !raw.trim().startsWith("{")) {
+      window.localStorage.removeItem(CALCULATOR_STORAGE_KEY);
+      return null;
+    }
+
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") {
       window.localStorage.removeItem(CALCULATOR_STORAGE_KEY);


### PR DESCRIPTION
## Summary
- clear out persisted calculator state if the stored payload is not JSON-formatted
- avoid invoking JSON.parse on values that were stringified via implicit object coercion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2857d6df08324883c7d1a8e2f249b