### PR TITLE
Fix numeric parsing for Greek thousands separator

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -1035,6 +1035,10 @@ function normaliseNumericString(
     decimalChar = ",";
   }
 
+  if (decimal !== "." && decimalChar === ".") {
+    decimalChar = null;
+  }
+
   let decimalIndex = decimalChar ? normalised.lastIndexOf(decimalChar) : -1;
 
   let integerPart = normalised;


### PR DESCRIPTION
## Summary
- ensure that the numeric normalisation logic never treats a period as a decimal separator when the active locale uses commas for decimals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e286b2a8ac832484c432d1f25b8126