### PR TITLE
Fix Greek numeric inputs and bump 0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,16 @@ TODO markers across the codebase for the current priorities.
 
 GreekTax tracks releases with the semantic pattern **R.X.Y**:
 
-- **R** – release cycle number signifying major public milestones. This only
-  increments when a full release is declared.
-- **X** – sprint-level increments that bundle new features or significant UI
-  updates. Increase this when a sprint concludes with a packaged deliverable.
-- **Y** – fix iterations for hot-fixes or polish delivered within a sprint.
-  Increment this for follow-up patches within the same sprint.
+- **Release** (`R`) – cycle number signifying major public milestones. This
+  only increments when a full release is declared.
+- **Major version** (`X`) – increments that bundle new features or significant
+  UI updates. Increase this when a sprint concludes with a packaged
+  deliverable.
+- **Minor version** (`Y`) – iterations for hot-fixes or polish delivered within
+  a sprint. Increment this for follow-up patches within the same sprint.
 
-The current milestone is **R.5.0** (version `0.5.0` in `pyproject.toml`),
-reflecting the fifth major sprint within the initial release cycle.
+The current milestone is **R.6.2** (version `0.6.2` in `pyproject.toml`),
+reflecting the sixth major sprint within the initial release cycle.
 
 The canonical version is declared once in [`pyproject.toml`](pyproject.toml) and
 is surfaced automatically via the `/api/v1/config/meta` endpoint and the UI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greektax"
-version = "0.6.0"
+version = "0.6.2"
 description = "Unofficial Greek tax estimation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -848,6 +848,7 @@
                   type="text"
                   inputmode="numeric"
                   data-numeric-input
+                  data-grouping="false"
                   data-precision="0"
                   min="1900"
                   max="2100"


### PR DESCRIPTION
## Summary
- simplify numeric input normalisation so dots are treated as thousands separators while allowing a decimal fallback and remove the locale symbol cache
- respect per-field grouping preferences by disabling thousands grouping on the freelance activity year field while keeping currency inputs grouped with cents
- bump the project version to 0.6.2 and refresh the README version terminology

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e286b2a8ac832484c432d1f25b8126