### PR TITLE
Stop auto-formatting calculator inputs and restore withholding labels

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -200,10 +200,7 @@
                 <input
                   id="children-input"
                   name="dependents.children"
-                  type="text"
-                  inputmode="numeric"
-                  data-numeric-input
-                  data-precision="0"
+                  type="number"
                   min="0"
                   step="1"
                   value="0"
@@ -418,10 +415,7 @@
                     <input
                       id="employment-employee-contributions"
                       name="employment.employee_contributions"
-                      type="text"
-                      inputmode="decimal"
-                      data-numeric-input
-                      data-precision="2"
+                      type="number"
                       min="0"
                       step="0.01"
                       value="0"
@@ -448,10 +442,7 @@
                 <input
                   id="employment-withholding"
                   name="withholding_tax"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -481,10 +472,7 @@
                 <input
                   id="employment-income"
                   name="employment.gross_income"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -514,10 +502,7 @@
                 <input
                   id="employment-monthly-income"
                   name="employment.monthly_income"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -603,10 +588,7 @@
                   <input
                     id="pension-income"
                     name="pension.gross_income"
-                    type="text"
-                    inputmode="decimal"
-                    data-numeric-input
-                    data-precision="2"
+                    type="number"
                     min="0"
                     step="0.01"
                     value="0"
@@ -670,10 +652,7 @@
                   <input
                     id="pension-net-income"
                     name="pension.net_income"
-                    type="text"
-                    inputmode="decimal"
-                    data-numeric-input
-                    data-precision="2"
+                    type="number"
                     min="0"
                     step="0.01"
                     value="0"
@@ -704,10 +683,7 @@
                   <input
                     id="pension-net-monthly-income"
                     name="pension.net_monthly_income"
-                    type="text"
-                    inputmode="decimal"
-                    data-numeric-input
-                    data-precision="2"
+                    type="number"
                     min="0"
                     step="0.01"
                     value="0"
@@ -755,10 +731,7 @@
                 <input
                   id="freelance-revenue"
                   name="freelance.gross_revenue"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -782,10 +755,7 @@
                 <input
                   id="freelance-expenses"
                   name="freelance.deductible_expenses"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -826,10 +796,7 @@
                 <input
                   id="freelance-efka-months"
                   name="freelance.efka_months"
-                  type="text"
-                  inputmode="numeric"
-                  data-numeric-input
-                  data-precision="0"
+                  type="number"
                   min="0"
                   max="24"
                   step="1"
@@ -845,11 +812,7 @@
                 </label>
                 <input
                   id="freelance-activity-start-year"
-                  type="text"
-                  inputmode="numeric"
-                  data-numeric-input
-                  data-grouping="false"
-                  data-precision="0"
+                  type="number"
                   min="1900"
                   max="2100"
                   step="1"
@@ -917,10 +880,7 @@
                     <input
                       id="freelance-contributions"
                       name="freelance.mandatory_contributions"
-                      type="text"
-                      inputmode="decimal"
-                      data-numeric-input
-                      data-precision="2"
+                      type="number"
                       min="0"
                       step="0.01"
                       value="0"
@@ -936,10 +896,7 @@
                     <input
                       id="freelance-auxiliary-contributions"
                       name="freelance.auxiliary_contributions"
-                      type="text"
-                      inputmode="decimal"
-                      data-numeric-input
-                      data-precision="2"
+                      type="number"
                       min="0"
                       step="0.01"
                       value="0"
@@ -955,10 +912,7 @@
                     <input
                       id="freelance-lump-sum-contributions"
                       name="freelance.lump_sum_contributions"
-                      type="text"
-                      inputmode="decimal"
-                      data-numeric-input
-                      data-precision="2"
+                      type="number"
                       min="0"
                       step="0.01"
                       value="0"
@@ -1020,10 +974,7 @@
                 <input
                   id="agricultural-revenue"
                   name="agricultural.gross_revenue"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1039,10 +990,7 @@
                 <input
                   id="agricultural-expenses"
                   name="agricultural.deductible_expenses"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1090,10 +1038,7 @@
                 <input
                   id="other-income"
                   name="other.taxable_income"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1126,10 +1071,7 @@
                 <input
                   id="rental-income"
                   name="rental.gross_income"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1145,10 +1087,7 @@
                 <input
                   id="rental-expenses"
                   name="rental.deductible_expenses"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1193,10 +1132,7 @@
                 <input
                   id="deductions-donations"
                   name="deductions.donations"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1212,10 +1148,7 @@
                 <input
                   id="deductions-medical"
                   name="deductions.medical"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1231,10 +1164,7 @@
                 <input
                   id="deductions-education"
                   name="deductions.education"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1250,10 +1180,7 @@
                 <input
                   id="deductions-insurance"
                   name="deductions.insurance"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1274,10 +1201,7 @@
                 <input
                   id="enfia-due"
                   name="obligations.enfia"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"
@@ -1290,10 +1214,7 @@
                 <input
                   id="luxury-due"
                   name="obligations.luxury"
-                  type="text"
-                  inputmode="decimal"
-                  data-numeric-input
-                  data-precision="2"
+                  type="number"
                   min="0"
                   step="0.01"
                   value="0"


### PR DESCRIPTION
## Summary
- convert calculator inputs to native number fields and drop auto-formatting logic
- simplify numeric validation/parsing and dynamically generated investment inputs
- fall back to translated labels for summary values when the API omits a label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e296adce448324be34cdce257841df