### PR TITLE
Fix checkbox display for business activity fee and farmer status

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -796,7 +796,7 @@ main {
   box-shadow: 0 0 0 1px rgba(var(--danger-rgb), 0.2);
 }
 
-.form-control input,
+.form-control input:not([type="checkbox"]):not([type="radio"]),
 .form-control select {
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
@@ -811,8 +811,23 @@ main {
   color: var(--text-body);
 }
 
-.form-control input {
+.form-control input:not([type="checkbox"]):not([type="radio"]) {
   appearance: none;
+}
+
+.form-control input[type="checkbox"] {
+  width: auto;
+  max-width: none;
+  margin: 0;
+  box-shadow: none;
+  background-color: transparent;
+  border-radius: 0.35rem;
+  accent-color: var(--primary-color, var(--field-focus));
+}
+
+.form-control input[type="checkbox"]:focus {
+  outline: 2px solid var(--field-focus);
+  outline-offset: 2px;
 }
 
 .form-control input[data-numeric-input] {


### PR DESCRIPTION
## Summary
- prevent generic form styles from applying to checkbox inputs so they keep their native appearance
- add explicit checkbox styling so the business activity fee and professional farmer status controls render correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e29dc0bfdc8324ba35d02158abe66f