### PR TITLE
Add taxable income summary field

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ GreekTax tracks releases with the semantic pattern **R.X.Y**:
 - **Minor version** (`Y`) – iterations for hot-fixes or polish delivered within
   a sprint. Increment this for follow-up patches within the same sprint.
 
-The current milestone is **R.6.2** (version `0.6.2` in `pyproject.toml`),
+The current milestone is **R.7.0** (version `0.7.0` in `pyproject.toml`),
 reflecting the sixth major sprint within the initial release cycle.
 
 The canonical version is declared once in [`pyproject.toml`](pyproject.toml) and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greektax"
-version = "0.6.2"
+version = "0.7.0"
 description = "Unofficial Greek tax estimation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -3091,6 +3091,7 @@ function renderSummary(summary) {
     { key: "net_monthly_income", formatter: formatCurrency },
     { key: "average_monthly_tax", formatter: formatCurrency },
     { key: "income_total", formatter: formatCurrency },
+    { key: "taxable_income", formatter: formatCurrency },
     { key: "effective_tax_rate", formatter: formatPercent },
   ];
 
@@ -3555,6 +3556,7 @@ function downloadCsvSummary() {
     { key: "net_monthly_income", formatter: formatCurrency },
     { key: "average_monthly_tax", formatter: formatCurrency },
     { key: "income_total", formatter: formatCurrency },
+    { key: "taxable_income", formatter: formatCurrency },
     { key: "effective_tax_rate", formatter: formatPercent },
   ];
 

--- a/src/frontend/assets/scripts/translations.generated.js
+++ b/src/frontend/assets/scripts/translations.generated.js
@@ -251,6 +251,7 @@
         "net_monthly_income": "Καθαρό εισόδημα ανά μήνα",
         "refund_due": "Επιστροφή φόρου",
         "tax_total": "Συνολικοί φόροι",
+        "taxable_income": "Φορολογητέο εισόδημα",
         "withholding_tax": "Παρακρατηθείς φόρος"
       },
       "ui": {
@@ -546,6 +547,7 @@
         "net_monthly_income": "Net income per month",
         "refund_due": "Refund due",
         "tax_total": "Total taxes",
+        "taxable_income": "Taxable income",
         "withholding_tax": "Tax already withheld"
       },
       "ui": {

--- a/src/greektax/backend/app/models/__init__.py
+++ b/src/greektax/backend/app/models/__init__.py
@@ -287,13 +287,22 @@ class DetailTotals:
     income: float = 0.0
     tax: float = 0.0
     net: float = 0.0
+    taxable: float = 0.0
 
-    def add(self, income: float = 0.0, tax: float = 0.0, net: float = 0.0) -> None:
+    def add(
+        self,
+        income: float = 0.0,
+        tax: float = 0.0,
+        net: float = 0.0,
+        taxable: float = 0.0,
+    ) -> None:
         self.income += income
         self.tax += tax
         self.net += net
+        self.taxable += taxable
 
     def merge(self, other: DetailTotals) -> None:
         self.income += other.income
         self.tax += other.tax
         self.net += other.net
+        self.taxable += other.taxable

--- a/src/greektax/backend/app/models/api.py
+++ b/src/greektax/backend/app/models/api.py
@@ -246,6 +246,7 @@ class SummaryLabels(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     income_total: str
+    taxable_income: str
     tax_total: str
     net_income: str
     net_monthly_income: str
@@ -263,6 +264,7 @@ class Summary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     income_total: float
+    taxable_income: float
     tax_total: float
     net_income: float
     net_monthly_income: float

--- a/src/greektax/backend/app/services/calculation_service.py
+++ b/src/greektax/backend/app/services/calculation_service.py
@@ -398,6 +398,10 @@ def _update_totals_from_detail(
     if isinstance(net, Real):
         totals.net += float(net)
 
+    taxable_income = detail.get("taxable_income")
+    if isinstance(taxable_income, Real):
+        totals.taxable += float(taxable_income)
+
 
 def calculate_tax(
     payload: Mapping[str, Any] | CalculationRequest,
@@ -476,6 +480,7 @@ def calculate_tax(
         _append_detail(luxury_detail)
 
     income_total = totals.income
+    taxable_total = totals.taxable
     tax_total = totals.tax
     net_income = totals.net
     net_monthly_income = net_income / 12 if net_income else 0.0
@@ -495,6 +500,7 @@ def calculate_tax(
 
     summary: dict[str, Any] = {
         "income_total": round_currency(income_total),
+        "taxable_income": round_currency(taxable_total),
         "tax_total": round_currency(tax_total),
         "net_income": round_currency(net_income),
         "net_monthly_income": round_currency(net_monthly_income),
@@ -504,6 +510,7 @@ def calculate_tax(
         "deductions_applied": round_currency(deductions_applied),
         "labels": {
             "income_total": translator("summary.income_total"),
+            "taxable_income": translator("summary.taxable_income"),
             "tax_total": translator("summary.tax_total"),
             "net_income": translator("summary.net_income"),
             "net_monthly_income": translator("summary.net_monthly_income"),

--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -38,11 +38,17 @@ def calculate_general_income_details(
     details: list[dict[str, Any]] = []
     totals = DetailTotals()
     for component in components:
-        detail, gross_income, total_tax, net_income = _detail_from_component(
+        (
+            detail,
+            gross_income,
+            taxable_income,
+            total_tax,
+            net_income,
+        ) = _detail_from_component(
             component, translator
         )
         details.append(detail)
-        totals.add(gross_income, total_tax, net_income)
+        totals.add(gross_income, total_tax, net_income, taxable_income)
 
     return details, deductions_applied, totals, deduction_breakdown
 
@@ -407,7 +413,7 @@ def _apply_deduction_credits(
 
 def _detail_from_component(
     component: GeneralIncomeComponent, translator: Translator
-) -> tuple[dict[str, Any], float, float, float]:
+) -> tuple[dict[str, Any], float, float, float, float]:
     (
         gross_income,
         taxable_income,
@@ -433,7 +439,7 @@ def _detail_from_component(
     _add_payment_structure_fields(detail, component)
     _add_deductions_field(detail, component)
 
-    return detail, gross_income, total_tax, net_income
+    return detail, gross_income, taxable_income, total_tax, net_income
 
 
 def _rounded_component_values(

--- a/src/greektax/translations/el.json
+++ b/src/greektax/translations/el.json
@@ -293,6 +293,7 @@
       "deductions_entered": "Καταχωρημένες εκπτώσεις",
       "effective_tax_rate": "Συνολικός φορολογικός συντελεστής",
       "income_total": "Συνολικό εισόδημα",
+      "taxable_income": "Φορολογητέο εισόδημα",
       "net_income": "Καθαρό εισόδημα",
       "net_monthly_income": "Καθαρό εισόδημα ανά μήνα",
       "refund_due": "Επιστροφή φόρου",

--- a/src/greektax/translations/en.json
+++ b/src/greektax/translations/en.json
@@ -293,6 +293,7 @@
       "deductions_entered": "Deductions entered",
       "effective_tax_rate": "Effective tax rate",
       "income_total": "Total income",
+      "taxable_income": "Taxable income",
       "net_income": "Net income",
       "net_monthly_income": "Net income per month",
       "refund_due": "Refund due",

--- a/tests/integration/test_calculation_endpoint.py
+++ b/tests/integration/test_calculation_endpoint.py
@@ -103,6 +103,7 @@ def test_calculation_endpoint_accepts_mixed_employment_inputs(client: FlaskClien
     result = response.get_json()
     summary = result["summary"]
     assert summary["income_total"] == pytest.approx(30_000.0)
+    assert summary["taxable_income"] == pytest.approx(30_000.0)
 
     employment_detail = next(
         item for item in result["details"] if item["category"] == "employment"


### PR DESCRIPTION
## Summary
- aggregate taxable income in the calculation response and expose translated labels
- display the taxable income field in the summary UI and CSV export
- update tests and bump the project version to 0.7.0

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2af3a82488324a2b856a7acd4ec74