### PR TITLE
Reorder summary fields by calculation flow

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -3082,16 +3082,16 @@ function renderSummary(summary) {
   summaryGrid.innerHTML = "";
   const labels = summary.labels || {};
   const summaryFields = [
-    { key: "net_income", formatter: formatCurrency, className: "primary" },
+    { key: "income_total", formatter: formatCurrency },
+    { key: "taxable_income", formatter: formatCurrency },
+    { key: "deductions_entered", formatter: formatCurrency },
+    { key: "deductions_applied", formatter: formatCurrency },
     { key: "tax_total", formatter: formatCurrency, className: "accent" },
     { key: "withholding_tax", formatter: formatCurrency },
     { key: "balance_due", formatter: formatCurrency, className: "accent" },
-    { key: "deductions_applied", formatter: formatCurrency },
-    { key: "deductions_entered", formatter: formatCurrency },
+    { key: "net_income", formatter: formatCurrency, className: "primary" },
     { key: "net_monthly_income", formatter: formatCurrency },
     { key: "average_monthly_tax", formatter: formatCurrency },
-    { key: "income_total", formatter: formatCurrency },
-    { key: "taxable_income", formatter: formatCurrency },
     { key: "effective_tax_rate", formatter: formatPercent },
   ];
 


### PR DESCRIPTION
## Summary
- reorder the summary grid fields so they progress from gross income through deductions to net income metrics
- retain existing highlighting for net income and liability-related values after the reorder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d38f1f4083248bcfbd238ea7ba98