### PR TITLE
Support multi-rate tax brackets and expose configuration metadata

### DIFF
--- a/src/greektax/backend/app/routes/config.py
+++ b/src/greektax/backend/app/routes/config.py
@@ -16,6 +16,7 @@ from greektax.backend.app.localization import get_translator, normalise_locale
 from greektax.backend.config.year_config import (
     ContributionRates,
     EFKACategoryConfig,
+    EmploymentConfig,
     PayrollConfig,
     TradeFeeConfig,
     YearWarning,
@@ -39,6 +40,14 @@ def _serialise_contributions(contributions: ContributionRates) -> dict[str, Any]
         "employee_rate": contributions.employee_rate,
         "employer_rate": contributions.employer_rate,
         "monthly_salary_cap": contributions.monthly_salary_cap,
+    }
+
+
+def _serialise_family_tax_credit(config: EmploymentConfig) -> dict[str, Any]:
+    return {
+        "pending_confirmation": config.family_tax_credit.pending_confirmation,
+        "estimate": config.family_tax_credit.estimate,
+        "reduction_factor": config.family_tax_credit.reduction_factor,
     }
 
 
@@ -98,6 +107,8 @@ def _serialise_year(year: int) -> dict[str, Any]:
         "employment": {
             "payroll": _serialise_payroll_config(config.employment.payroll),
             "contributions": _serialise_contributions(config.employment.contributions),
+            "family_tax_credit": _serialise_family_tax_credit(config.employment),
+            "tekmiria_reduction_factor": config.employment.tekmiria_reduction_factor,
         },
         "pension": {
             "payroll": _serialise_payroll_config(config.pension.payroll),
@@ -108,6 +119,7 @@ def _serialise_year(year: int) -> dict[str, Any]:
             "efka_categories": _serialise_efka_categories(
                 config.freelance.efka_categories
             ),
+            "pending_contribution_update": config.freelance.pending_contribution_update,
         },
         "warnings": [_serialise_warning(entry) for entry in config.warnings],
     }

--- a/src/greektax/backend/app/services/calculators/utils.py
+++ b/src/greektax/backend/app/services/calculators/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from greektax.backend.config.year_config import TaxBracket
+from greektax.backend.config.year_config import ProgressiveTaxBracket
 
 
 def format_percentage(value: float) -> str:
@@ -16,7 +16,9 @@ def format_percentage(value: float) -> str:
     return f"{percentage:.2f}%"
 
 
-def calculate_progressive_tax(amount: float, brackets: Sequence[TaxBracket]) -> float:
+def calculate_progressive_tax(
+    amount: float, brackets: Sequence[ProgressiveTaxBracket]
+) -> float:
     """Calculate progressive tax for ``amount`` using ``brackets``."""
 
     if amount <= 0:

--- a/src/greektax/backend/config/validator.py
+++ b/src/greektax/backend/config/validator.py
@@ -12,6 +12,9 @@ from .year_config import (
     DeductionHint,
     DeductionRuleConfig,
     EFKACategoryConfig,
+    EmploymentConfig,
+    FamilyTaxCreditMetadata,
+    FreelanceConfig,
     PayrollConfig,
     TradeFeeConfig,
     YearConfiguration,
@@ -135,6 +138,36 @@ def _validate_trade_fee(trade_fee: TradeFeeConfig) -> list[str]:
                     "sunset documentation URL must be absolute",
                 )
             )
+
+    return errors
+
+
+def _validate_family_tax_credit(metadata: FamilyTaxCreditMetadata) -> list[str]:
+    errors: list[str] = []
+
+    reduction = metadata.reduction_factor
+    if reduction is not None and reduction < 0:
+        errors.append(
+            _format_scope(
+                "employment.family_tax_credit",
+                "reduction_factor must be non-negative when provided",
+            )
+        )
+
+    return errors
+
+
+def _validate_tekmiria_reduction(config: EmploymentConfig) -> list[str]:
+    errors: list[str] = []
+
+    value = config.tekmiria_reduction_factor
+    if value is not None and value < 0:
+        errors.append(
+            _format_scope(
+                "employment.tekmiria_reduction_factor",
+                "value must be non-negative when provided",
+            )
+        )
 
     return errors
 
@@ -433,6 +466,8 @@ def validate_year_configuration(config: YearConfiguration) -> list[str]:
 
     errors.extend(_validate_trade_fee(config.freelance.trade_fee))
     errors.extend(_validate_efka_categories(config.freelance.efka_categories))
+    errors.extend(_validate_family_tax_credit(config.employment.family_tax_credit))
+    errors.extend(_validate_tekmiria_reduction(config.employment))
     errors.extend(_validate_investment_rates(config.investment.rates))
     errors.extend(_validate_deductions(config.deductions))
     errors.extend(_validate_warnings(config.warnings))


### PR DESCRIPTION
## Summary
- introduce new dataclasses for progressive brackets that capture dependant and youth rates alongside metadata
- update configuration parsing, validator logic, and serializers to handle multi-rate brackets, family tax credit metadata, tekmiria factors, and freelance contribution flags
- adjust calculator utilities to accept the expanded bracket types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d75fb92c8324aaa2d2f364712117