### PR TITLE
Improve summary result card color coding

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -56,6 +56,25 @@
   --summary-muted-bg: rgba(8, 23, 48, 0.06);
   --summary-base-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(231, 238, 252, 0.76));
   --summary-border: rgba(15, 109, 255, 0.15);
+  --summary-income-bg: linear-gradient(135deg, rgba(17, 70, 165, 0.14), rgba(15, 109, 255, 0.04));
+  --summary-income-border: rgba(17, 70, 165, 0.24);
+  --summary-income-text: #0c2f66;
+  --summary-deductions-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.18), rgba(15, 109, 255, 0.04));
+  --summary-deductions-border: rgba(0, 191, 166, 0.28);
+  --summary-deductions-text: #0a3f34;
+  --summary-tax-bg: linear-gradient(135deg, rgba(255, 77, 106, 0.22), rgba(255, 77, 106, 0.06));
+  --summary-tax-border: rgba(255, 77, 106, 0.32);
+  --summary-tax-text: #7f0d23;
+  --summary-withholding-bg: linear-gradient(135deg, rgba(247, 147, 26, 0.18), rgba(247, 147, 26, 0.08));
+  --summary-withholding-border: rgba(247, 147, 26, 0.26);
+  --summary-withholding-text: #8d4700;
+  --summary-net-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.2), rgba(15, 109, 255, 0.08));
+  --summary-net-border: rgba(0, 191, 166, 0.32);
+  --summary-balance-due-bg: linear-gradient(135deg, rgba(255, 77, 106, 0.28), rgba(214, 51, 132, 0.1));
+  --summary-balance-due-border: rgba(255, 77, 106, 0.38);
+  --summary-balance-refund-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.24), rgba(14, 109, 255, 0.12));
+  --summary-balance-refund-border: rgba(0, 191, 166, 0.34);
+  --summary-balance-refund-text: #0c5d4c;
   --summary-label: #1f3356;
   --detail-card-bg: rgba(255, 255, 255, 0.96);
   --detail-card-border: rgba(15, 109, 255, 0.14);
@@ -129,6 +148,25 @@
   --summary-primary-bg: linear-gradient(135deg, rgba(50, 224, 212, 0.38), rgba(14, 123, 166, 0.26));
   --summary-accent-bg: linear-gradient(135deg, rgba(255, 107, 139, 0.4), rgba(214, 51, 132, 0.24));
   --summary-muted-bg: rgba(9, 28, 39, 0.65);
+  --summary-income-bg: linear-gradient(135deg, rgba(21, 120, 198, 0.26), rgba(11, 53, 95, 0.4));
+  --summary-income-border: rgba(74, 184, 255, 0.38);
+  --summary-income-text: #d7e9ff;
+  --summary-deductions-bg: linear-gradient(135deg, rgba(17, 130, 120, 0.42), rgba(5, 31, 36, 0.68));
+  --summary-deductions-border: rgba(29, 221, 197, 0.45);
+  --summary-deductions-text: #dffdf8;
+  --summary-tax-bg: linear-gradient(135deg, rgba(194, 31, 58, 0.5), rgba(92, 20, 36, 0.7));
+  --summary-tax-border: rgba(255, 120, 154, 0.5);
+  --summary-tax-text: #ffd9e2;
+  --summary-withholding-bg: linear-gradient(135deg, rgba(247, 181, 71, 0.42), rgba(90, 52, 6, 0.68));
+  --summary-withholding-border: rgba(255, 208, 130, 0.5);
+  --summary-withholding-text: #ffe7c3;
+  --summary-net-bg: linear-gradient(135deg, rgba(29, 221, 197, 0.46), rgba(14, 123, 166, 0.32));
+  --summary-net-border: rgba(29, 221, 197, 0.48);
+  --summary-balance-due-bg: linear-gradient(135deg, rgba(194, 31, 58, 0.6), rgba(92, 20, 36, 0.7));
+  --summary-balance-due-border: rgba(255, 120, 154, 0.55);
+  --summary-balance-refund-bg: linear-gradient(135deg, rgba(29, 221, 197, 0.5), rgba(14, 123, 166, 0.36));
+  --summary-balance-refund-border: rgba(29, 221, 197, 0.52);
+  --summary-balance-refund-text: #dffdf8;
   --detail-card-bg: rgba(7, 16, 24, 0.92);
   --detail-card-border: rgba(50, 224, 212, 0.28);
   --breakdown-card-bg: rgba(9, 22, 33, 0.88);
@@ -973,6 +1011,73 @@ main {
   text-align: right;
 }
 
+.summary-item[data-field="income_total"],
+.summary-item[data-field="taxable_income"] {
+  background: var(--summary-income-bg);
+  border-color: var(--summary-income-border);
+}
+
+.summary-item[data-field="income_total"] dd,
+.summary-item[data-field="taxable_income"] dd {
+  color: var(--summary-income-text);
+}
+
+.summary-item[data-field="deductions_entered"],
+.summary-item[data-field="deductions_applied"] {
+  background: var(--summary-deductions-bg);
+  border-color: var(--summary-deductions-border);
+}
+
+.summary-item[data-field="deductions_entered"] dd,
+.summary-item[data-field="deductions_applied"] dd {
+  color: var(--summary-deductions-text);
+}
+
+.summary-item[data-field="tax_total"],
+.summary-item[data-field="average_monthly_tax"],
+.summary-item[data-field="effective_tax_rate"] {
+  background: var(--summary-tax-bg);
+  border-color: var(--summary-tax-border);
+}
+
+.summary-item[data-field="average_monthly_tax"] dd,
+.summary-item[data-field="effective_tax_rate"] dd {
+  color: var(--summary-tax-text);
+}
+
+.summary-item[data-field="withholding_tax"] {
+  background: var(--summary-withholding-bg);
+  border-color: var(--summary-withholding-border);
+}
+
+.summary-item[data-field="withholding_tax"] dd {
+  color: var(--summary-withholding-text);
+}
+
+.summary-item[data-field="net_income"],
+.summary-item[data-field="net_monthly_income"] {
+  background: var(--summary-net-bg);
+  border-color: var(--summary-net-border);
+}
+
+.summary-item[data-field="balance_due"][data-variant="due"] {
+  background: var(--summary-balance-due-bg);
+  border-color: var(--summary-balance-due-border);
+}
+
+.summary-item[data-field="balance_due"][data-variant="due"] dd {
+  color: var(--danger-color);
+}
+
+.summary-item[data-field="balance_due"][data-variant="refund"] {
+  background: var(--summary-balance-refund-bg);
+  border-color: var(--summary-balance-refund-border);
+}
+
+.summary-item[data-field="balance_due"][data-variant="refund"] dd {
+  color: var(--summary-balance-refund-text);
+}
+
 .details-list {
   margin-top: 1.5rem;
   display: grid;
@@ -1084,6 +1189,7 @@ main {
 }
 
 .summary-item dd[data-field="net_income"],
+.summary-item dd[data-field="net_monthly_income"],
 .detail-card dd[data-field="net_income"],
 .detail-card dd[data-field="net_income_per_payment"] {
   color: var(--success-color);


### PR DESCRIPTION
## Summary
- introduce themed color variables for income, deductions, tax, withholding, net, and balance results cards
- restyle calculator summary tiles with intuitive background and text colors for each data category in both light and dark themes
- highlight refunds and dues with category-appropriate accents while keeping positive income values in the success palette

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2dad75b148324b2d3c61650dcd063