### PR TITLE
Support youth relief brackets and demographic toggles

### DIFF
--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -46,6 +46,7 @@ schema. Unknown top-level or nested keys are rejected (`extra="forbid"`).
 | `year` | integer | ✅ | Tax year to evaluate. Must reference an available configuration file. |
 | `locale` | string | ❌ | BCP-47 locale code (`"en"` by default, `"el"` supported). Whitespace-only values default to `"en"`. |
 | `dependents` | object | ❌ | Household dependent information. Defaults to no dependents. |
+| `demographics` | object | ❌ | Taxpayer demographic data used for relief eligibility. Defaults to empty values. |
 | `employment` | object | ❌ | Employment income inputs. Defaults to zero amounts. |
 | `pension` | object | ❌ | Pension income inputs. Defaults to zero amounts. |
 | `freelance` | object | ❌ | Freelance/self-employment inputs. Defaults to zero amounts. |
@@ -55,6 +56,7 @@ schema. Unknown top-level or nested keys are rejected (`extra="forbid"`).
 | `other` | object | ❌ | Miscellaneous taxable income inputs. Defaults to zero amounts. |
 | `obligations` | object | ❌ | Flat obligations such as ENFIA and luxury tax. Defaults to zero amounts. |
 | `deductions` | object | ❌ | User-entered deduction amounts. Defaults to zero amounts. |
+| `toggles` | object | ❌ | Optional boolean feature flags (e.g., youth relief confirmation). Defaults to `{}`. |
 | `withholding_tax` | number | ❌ | Amount of tax already withheld. Defaults to `0`. Must be non-negative. |
 
 ### Dependents
@@ -62,6 +64,12 @@ schema. Unknown top-level or nested keys are rejected (`extra="forbid"`).
 | Field | Type | Required | Rules |
 | --- | --- | --- | --- |
 | `children` | integer | ❌ | Defaults to `0`. Must be ≥ 0. |
+
+### Demographics
+
+| Field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `taxpayer_birth_year` | integer | ❌ | Defaults to `null`. When provided it must be between 1900 and 2100. Used to derive age brackets for youth relief calculations. |
 
 ### Employment & Pension sections
 

--- a/src/greektax/backend/app/services/calculation_service.py
+++ b/src/greektax/backend/app/services/calculation_service.py
@@ -95,6 +95,8 @@ def _normalise_payload(
     locale = request.locale or "en"
 
     children = request.dependents.children
+    demographics = request.demographics
+    toggles = MappingProxyType(dict(request.toggles)) if request.toggles else MappingProxyType({})
 
     employment_input = request.employment
     employment_payroll = config.employment.payroll
@@ -233,6 +235,7 @@ def _normalise_payload(
         year=request.year,
         locale=locale,
         children=children,
+        taxpayer_birth_year=demographics.taxpayer_birth_year,
         employment_income=employment_income,
         employment_monthly_income=employment_monthly_income,
         employment_payments_per_year=employment_payments,
@@ -270,6 +273,7 @@ def _normalise_payload(
         deductions_medical=deductions_medical,
         deductions_education=deductions_education,
         deductions_insurance=deductions_insurance,
+        toggles=toggles,
     )
 
     return _apply_net_targets(normalised, config)

--- a/src/greektax/backend/app/services/calculators/utils.py
+++ b/src/greektax/backend/app/services/calculators/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from greektax.backend.config.year_config import ProgressiveTaxBracket
 
@@ -37,6 +37,117 @@ def calculate_progressive_tax(
         lower_bound = upper
 
     return total
+
+
+def allocate_progressive_tax(
+    amounts: Sequence[float],
+    brackets: Sequence[ProgressiveTaxBracket],
+    rate_resolver: Callable[[int, ProgressiveTaxBracket], float],
+) -> list[float]:
+    """Distribute progressive tax across ``amounts`` using ``brackets``.
+
+    Parameters
+    ----------
+    amounts:
+        Taxable income per component. Negative values are treated as zero.
+    brackets:
+        Progressive tax brackets to apply.
+    rate_resolver:
+        Callable returning the applicable rate for the ``component`` index and
+        current ``bracket``. Allows callers to plug in household or youth rate
+        tables when ``MultiRateBracket`` instances are supplied.
+    """
+
+    if not amounts:
+        return []
+
+    remaining = [amount if amount > 0 else 0.0 for amount in amounts]
+    taxes = [0.0 for _ in amounts]
+
+    total_remaining = sum(remaining)
+    if total_remaining <= 0:
+        return taxes
+
+    lower_bound = 0.0
+
+    for bracket in brackets:
+        upper = bracket.upper_bound
+        if upper is None:
+            bracket_capacity = total_remaining
+        else:
+            bracket_capacity = upper - lower_bound
+            if bracket_capacity < 0:
+                bracket_capacity = 0.0
+            if bracket_capacity > total_remaining:
+                bracket_capacity = total_remaining
+
+        if bracket_capacity <= 0:
+            lower_bound = upper if upper is not None else lower_bound
+            continue
+
+        active_indices = [index for index, value in enumerate(remaining) if value > 0]
+        if not active_indices:
+            break
+
+        active_total = sum(remaining[index] for index in active_indices)
+        if active_total <= 0:
+            break
+
+        allocations: dict[int, float] = {}
+        allocated = 0.0
+
+        for position, index in enumerate(active_indices):
+            remaining_income = remaining[index]
+            if remaining_income <= 0:
+                continue
+
+            if position == len(active_indices) - 1:
+                allocation = min(remaining_income, bracket_capacity - allocated)
+            else:
+                share = remaining_income / active_total
+                allocation = bracket_capacity * share
+                if allocation > remaining_income:
+                    allocation = remaining_income
+                remaining_capacity = bracket_capacity - allocated
+                if allocation > remaining_capacity:
+                    allocation = remaining_capacity
+
+            if allocation < 0:
+                allocation = 0.0
+
+            allocations[index] = allocation
+            allocated += allocation
+
+        leftover = bracket_capacity - allocated
+        if leftover > 1e-9:
+            for index in active_indices:
+                if leftover <= 1e-9:
+                    break
+                remaining_income = remaining[index] - allocations.get(index, 0.0)
+                if remaining_income <= 0:
+                    continue
+                extra = remaining_income if remaining_income < leftover else leftover
+                if extra <= 0:
+                    continue
+                allocations[index] = allocations.get(index, 0.0) + extra
+                allocated += extra
+                leftover -= extra
+
+        for index, allocation in allocations.items():
+            if allocation <= 0:
+                continue
+            rate = rate_resolver(index, bracket)
+            taxes[index] += allocation * rate
+            remaining[index] -= allocation
+            if remaining[index] < 0:
+                remaining[index] = 0.0
+
+        total_remaining -= bracket_capacity
+        if total_remaining <= 1e-9:
+            break
+        lower_bound = upper if upper is not None else lower_bound
+
+    return taxes
 
 
 def round_currency(value: float) -> float:


### PR DESCRIPTION
## Summary
- add demographic and toggle inputs to the API contract and calculation payload to derive youth rate eligibility
- apply progressive tax allocation that selects household or youth rates per component and honour the trade fee sunset flag
- document the new inputs and cover youth relief behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ddb32b888324a359ebe46d38d3f5