### PR TITLE
Default demographic toggles to off by default

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -1038,6 +1038,46 @@ function sanitiseToggleMap(source) {
   return toggles;
 }
 
+function resolveStoredToggleValue(element) {
+  if (!element) {
+    return false;
+  }
+
+  const key = element.id;
+  if (
+    key &&
+    pendingCalculatorState &&
+    Object.prototype.hasOwnProperty.call(pendingCalculatorState, key)
+  ) {
+    return Boolean(pendingCalculatorState[key]);
+  }
+
+  return Boolean(element.defaultChecked);
+}
+
+function syncDemographicToggleState(key, control, toggleElement, isAvailable) {
+  if (control) {
+    control.hidden = !isAvailable;
+  }
+
+  if (!toggleElement) {
+    if (!isAvailable) {
+      delete currentYearToggles[key];
+    }
+    return;
+  }
+
+  if (!isAvailable) {
+    toggleElement.checked = Boolean(toggleElement.defaultChecked);
+    delete currentYearToggles[key];
+    return;
+  }
+
+  const desired = resolveStoredToggleValue(toggleElement);
+  toggleElement.checked = desired;
+  currentYearToggles[key] = desired;
+}
+
 function applyContributionDefaults(metadata) {
   const employmentDefaults =
     (metadata && metadata.employment && metadata.employment.defaults) || {};
@@ -1069,40 +1109,34 @@ function updateDemographicToggles(metadata, toggles) {
     toggles,
     "youth_eligibility",
   );
-  if (youthEligibilityControl) {
-    youthEligibilityControl.hidden = !hasYouthToggle;
-  }
-  if (youthEligibilityToggle) {
-    youthEligibilityToggle.checked = hasYouthToggle
-      ? Boolean(toggles.youth_eligibility)
-      : Boolean(youthEligibilityToggle.defaultChecked);
-  }
+  syncDemographicToggleState(
+    "youth_eligibility",
+    youthEligibilityControl,
+    youthEligibilityToggle,
+    hasYouthToggle,
+  );
 
   const hasSmallVillage = Object.prototype.hasOwnProperty.call(
     toggles,
     "small_village",
   );
-  if (smallVillageControl) {
-    smallVillageControl.hidden = !hasSmallVillage;
-  }
-  if (smallVillageToggle) {
-    smallVillageToggle.checked = hasSmallVillage
-      ? Boolean(toggles.small_village)
-      : Boolean(smallVillageToggle.defaultChecked);
-  }
+  syncDemographicToggleState(
+    "small_village",
+    smallVillageControl,
+    smallVillageToggle,
+    hasSmallVillage,
+  );
 
   const hasNewMother = Object.prototype.hasOwnProperty.call(
     toggles,
     "new_mother",
   );
-  if (newMotherControl) {
-    newMotherControl.hidden = !hasNewMother;
-  }
-  if (newMotherToggle) {
-    newMotherToggle.checked = hasNewMother
-      ? Boolean(toggles.new_mother)
-      : Boolean(newMotherToggle.defaultChecked);
-  }
+  syncDemographicToggleState(
+    "new_mother",
+    newMotherControl,
+    newMotherToggle,
+    hasNewMother,
+  );
 }
 
 function computeBracketRangeLabel(bracket, index, previousUpper) {


### PR DESCRIPTION
## Summary
- ensure demographic relief toggles default to unchecked while still respecting any stored values
- keep current-year toggle state in sync when controls are hidden or shown so clearing the form resets everything

## Testing
- Manual: Loaded the static frontend via python -m http.server and verified the demographic toggles render unchecked by default


------
https://chatgpt.com/codex/tasks/task_e_68e2f3380bfc8324b545f2803b41eb08