### PR TITLE
Update 2026 bracket schedule to confirmed AADE rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ for guidance on interpreting the output.
   maintaining audit-friendly detail rows in the response payload.【F:src/greektax/backend/app/services/calculation_service.py†L904-L1020】
 - Trade fee handling reflects the latest filing guidance, only adding the charge
   for professions or start years that require it.【F:src/greektax/backend/app/services/calculation_service.py†L702-L776】
-- Preliminary 2026 brackets include youth-rate relief, refreshed dependant credit
-  tiers pending confirmation, and a lower rental mid-band while freelance EFKA
-  categories remain flagged as estimates pending confirmation from EFKA.【F:src/greektax/backend/config/data/2026.yaml†L5-L141】【F:src/greektax/backend/config/data/2026.yaml†L220-L333】【F:src/greektax/backend/config/data/2026.yaml†L450-L520】
+- The 2026 wage and pension brackets now mirror the confirmed youth and large-
+  family relief schedule, while dependant credits, rental updates, and freelance
+  EFKA bands remain provisional pending official circulars.【F:src/greektax/backend/config/data/2026.yaml†L1-L141】【F:src/greektax/backend/config/data/2026.yaml†L220-L333】【F:src/greektax/backend/config/data/2026.yaml†L450-L520】
 
 ## Configuring the API endpoint
 

--- a/src/greektax/backend/config/data/2026.yaml
+++ b/src/greektax/backend/config/data/2026.yaml
@@ -2,7 +2,7 @@ year: 2026
 meta:
   version: 1
   status: draft
-  notes: "Preliminary 2026 configuration with household brackets and youth relief toggles"
+  notes: "2026 configuration with confirmed wage and pension brackets plus provisional credits"
   toggles:
     youth_eligibility: true
     small_village: true
@@ -22,71 +22,89 @@ income:
       employer_rate: 0.2179
       monthly_salary_cap: 7572.62
     tax_brackets:
-      - upper: 12000
+      - upper: 10000
         rates:
           household:
             dependants:
-              0: 0.085
-              1: 0.08
-              2: 0.075
-              3: 0.07
-              4: 0.065
-            reduction_factor: 0.02
+              0: 0.09
+              1: 0.09
+              2: 0.09
+              3: 0.09
+              4: 0.0
+              5: 0.0
+              6: 0.0
           youth:
-            under_25: 0.05
-            age26_30: 0.06
-      - upper: 24000
+            under_25: 0.0
+            age26_30: 0.09
+      - upper: 20000
         rates:
           household:
             dependants:
-              0: 0.22
-              1: 0.215
-              2: 0.205
-              3: 0.195
-              4: 0.185
-            reduction_factor: 0.015
+              0: 0.2
+              1: 0.18
+              2: 0.16
+              3: 0.09
+              4: 0.0
+              5: 0.0
+              6: 0.0
           youth:
-            under_25: 0.18
-            age26_30: 0.195
-      - upper: 36000
+            under_25: 0.0
+            age26_30: 0.09
+      - upper: 30000
         rates:
           household:
             dependants:
-              0: 0.29
-              1: 0.285
-              2: 0.275
-              3: 0.265
-              4: 0.255
-            reduction_factor: 0.01
+              0: 0.26
+              1: 0.24
+              2: 0.22
+              3: 0.2
+              4: 0.18
+              5: 0.16
+              6: 0.14
           youth:
-            under_25: 0.23
-            age26_30: 0.255
-      - upper: 50000
+            under_25: 0.26
+            age26_30: 0.26
+      - upper: 40000
         rates:
           household:
             dependants:
-              0: 0.37
-              1: 0.365
-              2: 0.355
-              3: 0.345
-              4: 0.335
-            reduction_factor: 0.01
+              0: 0.34
+              1: 0.34
+              2: 0.34
+              3: 0.34
+              4: 0.34
+              5: 0.34
+              6: 0.34
           youth:
-            under_25: 0.3
-            age26_30: 0.32
+            under_25: 0.34
+            age26_30: 0.34
+      - upper: 60000
+        rates:
+          household:
+            dependants:
+              0: 0.39
+              1: 0.39
+              2: 0.39
+              3: 0.39
+              4: 0.39
+              5: 0.39
+              6: 0.39
+          youth:
+            under_25: 0.39
+            age26_30: 0.39
       - rates:
           household:
             dependants:
-              0: 0.45
-              1: 0.445
-              2: 0.435
-              3: 0.425
-              4: 0.415
-            reduction_factor: 0.01
+              0: 0.44
+              1: 0.44
+              2: 0.44
+              3: 0.44
+              4: 0.44
+              5: 0.44
+              6: 0.44
           youth:
-            under_25: 0.36
-            age26_30: 0.38
-        pending_confirmation: true
+            under_25: 0.44
+            age26_30: 0.44
     tax_credit:
       amounts_by_children:
         "0": 778
@@ -111,71 +129,89 @@ income:
       employee_rate: 0.0
       employer_rate: 0.0
     tax_brackets:
-      - upper: 12000
+      - upper: 10000
         rates:
           household:
             dependants:
-              0: 0.085
-              1: 0.08
-              2: 0.075
-              3: 0.07
-              4: 0.065
-            reduction_factor: 0.02
+              0: 0.09
+              1: 0.09
+              2: 0.09
+              3: 0.09
+              4: 0.0
+              5: 0.0
+              6: 0.0
           youth:
-            under_25: 0.05
-            age26_30: 0.06
-      - upper: 24000
+            under_25: 0.0
+            age26_30: 0.09
+      - upper: 20000
         rates:
           household:
             dependants:
-              0: 0.22
-              1: 0.215
-              2: 0.205
-              3: 0.195
-              4: 0.185
-            reduction_factor: 0.015
+              0: 0.2
+              1: 0.18
+              2: 0.16
+              3: 0.09
+              4: 0.0
+              5: 0.0
+              6: 0.0
           youth:
-            under_25: 0.18
-            age26_30: 0.195
-      - upper: 36000
+            under_25: 0.0
+            age26_30: 0.09
+      - upper: 30000
         rates:
           household:
             dependants:
-              0: 0.29
-              1: 0.285
-              2: 0.275
-              3: 0.265
-              4: 0.255
-            reduction_factor: 0.01
+              0: 0.26
+              1: 0.24
+              2: 0.22
+              3: 0.2
+              4: 0.18
+              5: 0.16
+              6: 0.14
           youth:
-            under_25: 0.23
-            age26_30: 0.255
-      - upper: 50000
+            under_25: 0.26
+            age26_30: 0.26
+      - upper: 40000
         rates:
           household:
             dependants:
-              0: 0.37
-              1: 0.365
-              2: 0.355
-              3: 0.345
-              4: 0.335
-            reduction_factor: 0.01
+              0: 0.34
+              1: 0.34
+              2: 0.34
+              3: 0.34
+              4: 0.34
+              5: 0.34
+              6: 0.34
           youth:
-            under_25: 0.3
-            age26_30: 0.32
+            under_25: 0.34
+            age26_30: 0.34
+      - upper: 60000
+        rates:
+          household:
+            dependants:
+              0: 0.39
+              1: 0.39
+              2: 0.39
+              3: 0.39
+              4: 0.39
+              5: 0.39
+              6: 0.39
+          youth:
+            under_25: 0.39
+            age26_30: 0.39
       - rates:
           household:
             dependants:
-              0: 0.45
-              1: 0.445
-              2: 0.435
-              3: 0.425
-              4: 0.415
-            reduction_factor: 0.01
+              0: 0.44
+              1: 0.44
+              2: 0.44
+              3: 0.44
+              4: 0.44
+              5: 0.44
+              6: 0.44
           youth:
-            under_25: 0.36
-            age26_30: 0.38
-        pending_confirmation: true
+            under_25: 0.44
+            age26_30: 0.44
   freelance:
     tax_brackets:
       - upper: 12000

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -325,15 +325,15 @@
     "expectations": {
       "summary": {
         "income_total": 54000.0,
-        "tax_total": 6708.97,
-        "net_income": 41547.43,
-        "average_monthly_tax": 559.08
+        "tax_total": 4996.66,
+        "net_income": 43259.74,
+        "average_monthly_tax": 416.39
       },
       "details": {
         "employment": {
-          "tax_before_credits": 2818.97,
+          "tax_before_credits": 1106.66,
           "credits": 910.0,
-          "total_tax": 1908.97,
+          "total_tax": 196.66,
           "employee_contributions": 3743.6
         },
         "rental": {
@@ -357,9 +357,9 @@
     "expectations": {
       "summary": {
         "income_total": 18000.0,
-        "tax_total": 1339.86,
-        "net_income": 12114.06,
-        "average_monthly_tax": 111.65
+        "tax_total": 1590.78,
+        "net_income": 11863.14,
+        "average_monthly_tax": 132.56
       },
       "details": {
         "freelance": {
@@ -368,7 +368,7 @@
           "category_contributions": 3946.08,
           "additional_contributions": 600.0,
           "trade_fee": 0.0,
-          "total_tax": 1339.86
+          "total_tax": 1590.78
         }
       }
     }


### PR DESCRIPTION
## Summary
- align the 2026 employment and pension tax brackets with the confirmed youth and dependant relief schedule
- refresh the README to note the confirmed wage and pension bands while leaving other provisional items flagged
- update regression fixtures and youth relief unit test expectations to reflect the new bracket calculations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2fc9f49508324ab5686b87da191c0