### PR TITLE
Update distribution chart income labels

### DIFF
--- a/src/frontend/assets/scripts/translations.generated.js
+++ b/src/frontend/assets/scripts/translations.generated.js
@@ -62,14 +62,14 @@
         "trade_fee": "Τέλος επιτηδεύματος"
       },
       "distribution": {
-        "description": "Δείτε πώς κατανέμεται το συνολικό εισόδημα μεταξύ κερδών, φόρων, ασφαλιστικών εισφορών και εκπιπτόμενων δαπανών.",
+        "description": "Δείτε πώς κατανέμεται το συνολικό εισόδημα μεταξύ καθαρού εισοδήματος, φόρων, ασφαλιστικών εισφορών και δαπανών.",
         "empty": "Προσθέστε φορολογητέο εισόδημα για να εμφανιστεί η κατανομή σε όλες τις κατηγορίες.",
         "expenses": "Δαπάνες",
         "heading": "Κατανομή συνολικού εισοδήματος",
+        "gross_income": "Ακαθάριστο εισόδημα",
         "insurance": "Ασφαλιστικές εισφορές",
-        "profits": "Κέρδη",
-        "taxes": "Φόροι",
-        "total_income": "Συνολικό εισόδημα"
+        "net_income": "Καθαρό εισόδημα",
+        "taxes": "Φόροι"
       },
       "errors": {
         "invalid_number": "Εισαγάγετε έγκυρο αριθμό για {{field}}.",
@@ -397,14 +397,14 @@
         "trade_fee": "Business activity fee"
       },
       "distribution": {
-        "description": "See how your total income is split between profits, taxes, insurance contributions, and deductible expenses.",
+        "description": "See how your total income is split between net income, taxes, insurance contributions, and expenses.",
         "empty": "Add taxable income above to reveal the allocation across all categories.",
         "expenses": "Expenses",
         "heading": "Income allocation summary",
+        "gross_income": "Gross income",
         "insurance": "Insurance contributions",
-        "profits": "Profits",
-        "taxes": "Taxes",
-        "total_income": "Total income"
+        "net_income": "Net income",
+        "taxes": "Taxes"
       },
       "errors": {
         "invalid_number": "Please enter a valid number for {{field}}.",

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1467,8 +1467,8 @@
               class="distribution-intro"
               data-i18n-key="distribution.description"
             >
-              See how your total income splits between profits, taxes,
-              insurance contributions, and deductible expenses.
+              See how your total income splits between net income, taxes,
+              insurance contributions, and expenses.
             </p>
             <p
               id="distribution-empty"


### PR DESCRIPTION
## Summary
- rename the distribution chart profits bucket to net income and reorder the donut data so the accessible text starts at gross income
- recompute totals from summed gross income and update the center label to use the new gross income translation key
- refresh English and Greek copy so descriptions and tooltips mention net income, taxes, insurance contributions, and expenses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e30e837ed88324a8b1abbed6454e84