### PR TITLE
Align results styling with flow color tokens

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -13,6 +13,14 @@
   --text-body: #0a1c33;
   --text-subtle: #243a63;
   --text-muted: #566789;
+  --flow-net-strong-text: color-mix(in srgb, var(--flow-net) 70%, var(--text-body));
+  --flow-taxes-strong-text: color-mix(in srgb, var(--flow-taxes) 72%, var(--text-body));
+  --flow-contributions-strong-text: color-mix(
+    in srgb,
+    var(--flow-contributions) 68%,
+    var(--text-body)
+  );
+  --flow-expenses-strong-text: color-mix(in srgb, var(--flow-expenses) 70%, var(--text-body));
   --card-border: rgba(12, 64, 150, 0.1);
   --card-shadow: 0 1.25rem 2.75rem rgba(7, 20, 43, 0.14);
   --gradient-top: #f7f9ff;
@@ -59,22 +67,50 @@
   --summary-income-bg: linear-gradient(135deg, rgba(17, 70, 165, 0.14), rgba(15, 109, 255, 0.04));
   --summary-income-border: rgba(17, 70, 165, 0.24);
   --summary-income-text: #0c2f66;
-  --summary-deductions-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.18), rgba(15, 109, 255, 0.04));
-  --summary-deductions-border: rgba(0, 191, 166, 0.28);
-  --summary-deductions-text: #0a3f34;
-  --summary-tax-bg: linear-gradient(135deg, rgba(255, 77, 106, 0.22), rgba(255, 77, 106, 0.06));
-  --summary-tax-border: rgba(255, 77, 106, 0.32);
-  --summary-tax-text: #7f0d23;
-  --summary-withholding-bg: linear-gradient(135deg, rgba(247, 147, 26, 0.18), rgba(247, 147, 26, 0.08));
-  --summary-withholding-border: rgba(247, 147, 26, 0.26);
-  --summary-withholding-text: #8d4700;
-  --summary-net-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.2), rgba(15, 109, 255, 0.08));
-  --summary-net-border: rgba(0, 191, 166, 0.32);
-  --summary-balance-due-bg: linear-gradient(135deg, rgba(255, 77, 106, 0.28), rgba(214, 51, 132, 0.1));
-  --summary-balance-due-border: rgba(255, 77, 106, 0.38);
-  --summary-balance-refund-bg: linear-gradient(135deg, rgba(0, 191, 166, 0.24), rgba(14, 109, 255, 0.12));
-  --summary-balance-refund-border: rgba(0, 191, 166, 0.34);
-  --summary-balance-refund-text: #0c5d4c;
+  --summary-deductions-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-contributions) 24%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-contributions) 8%, var(--surface-base))
+  );
+  --summary-deductions-border: color-mix(
+    in srgb,
+    var(--flow-contributions) 32%,
+    var(--surface-base)
+  );
+  --summary-deductions-text: var(--flow-contributions-strong-text);
+  --summary-tax-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-taxes) 26%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-taxes) 10%, var(--surface-base))
+  );
+  --summary-tax-border: color-mix(in srgb, var(--flow-taxes) 34%, var(--surface-base));
+  --summary-tax-text: var(--flow-taxes-strong-text);
+  --summary-withholding-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-expenses) 24%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-expenses) 10%, var(--surface-base))
+  );
+  --summary-withholding-border: color-mix(in srgb, var(--flow-expenses) 32%, var(--surface-base));
+  --summary-withholding-text: var(--flow-expenses-strong-text);
+  --summary-net-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-net) 24%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-net) 8%, var(--surface-base))
+  );
+  --summary-net-border: color-mix(in srgb, var(--flow-net) 32%, var(--surface-base));
+  --summary-balance-due-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-taxes) 32%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-taxes) 14%, var(--surface-base))
+  );
+  --summary-balance-due-border: color-mix(in srgb, var(--flow-taxes) 38%, var(--surface-base));
+  --summary-balance-refund-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-net) 30%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-net) 12%, var(--surface-base))
+  );
+  --summary-balance-refund-border: color-mix(in srgb, var(--flow-net) 36%, var(--surface-base));
+  --summary-balance-refund-text: var(--flow-net-strong-text);
   --summary-label: #1f3356;
   --detail-card-bg: rgba(255, 255, 255, 0.96);
   --detail-card-border: rgba(15, 109, 255, 0.14);
@@ -133,6 +169,14 @@
   --danger-color: #ff6b8b;
   --danger-rgb: 255, 107, 139;
   --success-color: #32e0d4;
+  --flow-net-strong-text: color-mix(in srgb, var(--flow-net) 60%, var(--text-body));
+  --flow-taxes-strong-text: color-mix(in srgb, var(--flow-taxes) 64%, var(--text-body));
+  --flow-contributions-strong-text: color-mix(
+    in srgb,
+    var(--flow-contributions) 60%,
+    var(--text-body)
+  );
+  --flow-expenses-strong-text: color-mix(in srgb, var(--flow-expenses) 62%, var(--text-body));
   --button-primary-bg: linear-gradient(135deg, #32e0d4, #0e7ba6);
   --button-primary-text: #031317;
   --button-primary-hover: linear-gradient(135deg, #28c3ba, #0c688c);
@@ -151,22 +195,50 @@
   --summary-income-bg: linear-gradient(135deg, rgba(21, 120, 198, 0.26), rgba(11, 53, 95, 0.4));
   --summary-income-border: rgba(74, 184, 255, 0.38);
   --summary-income-text: #d7e9ff;
-  --summary-deductions-bg: linear-gradient(135deg, rgba(17, 130, 120, 0.42), rgba(5, 31, 36, 0.68));
-  --summary-deductions-border: rgba(29, 221, 197, 0.45);
-  --summary-deductions-text: #dffdf8;
-  --summary-tax-bg: linear-gradient(135deg, rgba(194, 31, 58, 0.5), rgba(92, 20, 36, 0.7));
-  --summary-tax-border: rgba(255, 120, 154, 0.5);
-  --summary-tax-text: #ffd9e2;
-  --summary-withholding-bg: linear-gradient(135deg, rgba(247, 181, 71, 0.42), rgba(90, 52, 6, 0.68));
-  --summary-withholding-border: rgba(255, 208, 130, 0.5);
-  --summary-withholding-text: #ffe7c3;
-  --summary-net-bg: linear-gradient(135deg, rgba(29, 221, 197, 0.46), rgba(14, 123, 166, 0.32));
-  --summary-net-border: rgba(29, 221, 197, 0.48);
-  --summary-balance-due-bg: linear-gradient(135deg, rgba(194, 31, 58, 0.6), rgba(92, 20, 36, 0.7));
-  --summary-balance-due-border: rgba(255, 120, 154, 0.55);
-  --summary-balance-refund-bg: linear-gradient(135deg, rgba(29, 221, 197, 0.5), rgba(14, 123, 166, 0.36));
-  --summary-balance-refund-border: rgba(29, 221, 197, 0.52);
-  --summary-balance-refund-text: #dffdf8;
+  --summary-deductions-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-contributions) 32%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-contributions) 18%, var(--surface-base))
+  );
+  --summary-deductions-border: color-mix(
+    in srgb,
+    var(--flow-contributions) 48%,
+    var(--surface-base)
+  );
+  --summary-deductions-text: var(--flow-contributions-strong-text);
+  --summary-tax-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-taxes) 36%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-taxes) 22%, var(--surface-base))
+  );
+  --summary-tax-border: color-mix(in srgb, var(--flow-taxes) 52%, var(--surface-base));
+  --summary-tax-text: var(--flow-taxes-strong-text);
+  --summary-withholding-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-expenses) 34%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-expenses) 18%, var(--surface-base))
+  );
+  --summary-withholding-border: color-mix(in srgb, var(--flow-expenses) 50%, var(--surface-base));
+  --summary-withholding-text: var(--flow-expenses-strong-text);
+  --summary-net-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-net) 34%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-net) 20%, var(--surface-base))
+  );
+  --summary-net-border: color-mix(in srgb, var(--flow-net) 50%, var(--surface-base));
+  --summary-balance-due-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-taxes) 44%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-taxes) 26%, var(--surface-base))
+  );
+  --summary-balance-due-border: color-mix(in srgb, var(--flow-taxes) 58%, var(--surface-base));
+  --summary-balance-refund-bg: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--flow-net) 42%, var(--surface-raised)),
+    color-mix(in srgb, var(--flow-net) 24%, var(--surface-base))
+  );
+  --summary-balance-refund-border: color-mix(in srgb, var(--flow-net) 56%, var(--surface-base));
+  --summary-balance-refund-text: var(--flow-net-strong-text);
   --detail-card-bg: rgba(7, 16, 24, 0.92);
   --detail-card-border: rgba(50, 224, 212, 0.28);
   --breakdown-card-bg: rgba(9, 22, 33, 0.88);
@@ -1040,6 +1112,7 @@ main {
   border-color: var(--summary-tax-border);
 }
 
+.summary-item[data-field="tax_total"] dd,
 .summary-item[data-field="average_monthly_tax"] dd,
 .summary-item[data-field="effective_tax_rate"] dd {
   color: var(--summary-tax-text);
@@ -1066,7 +1139,7 @@ main {
 }
 
 .summary-item[data-field="balance_due"][data-variant="due"] dd {
-  color: var(--danger-color);
+  color: var(--flow-taxes-strong-text);
 }
 
 .summary-item[data-field="balance_due"][data-variant="refund"] {
@@ -1175,7 +1248,7 @@ main {
 }
 
 .detail-breakdown__tax {
-  color: var(--danger-color);
+  color: var(--flow-taxes-strong-text);
 }
 
 .detail-breakdown__rate {
@@ -1192,18 +1265,20 @@ main {
 .summary-item dd[data-field="net_monthly_income"],
 .detail-card dd[data-field="net_income"],
 .detail-card dd[data-field="net_income_per_payment"] {
-  color: var(--success-color);
+  color: var(--flow-net-strong-text);
 }
 
-.summary-item dd[data-field="tax_total"],
 .detail-card dd[data-field="tax"],
 .detail-card dd[data-field="total_tax"] {
-  color: var(--danger-color);
+  color: var(--flow-taxes-strong-text);
 }
 
-.detail-card dd[data-field="deductible_contributions"],
+.detail-card dd[data-field="deductible_contributions"] {
+  color: var(--flow-contributions-strong-text);
+}
+
 .detail-card dd[data-field="deductible_expenses"] {
-  color: var(--link-accent);
+  color: var(--flow-expenses-strong-text);
 }
 
 .detail-card dd[data-field="payments_per_year"] {


### PR DESCRIPTION
## Summary
- derive net, tax, contribution, and expense summary gradients directly from the flow color tokens in both light and dark themes
- update summary tiles, detail cards, and breakdown accents to use the flow-derived text colors instead of the old success/danger/link accents
- keep helper styling consistent so balance due, contributions, and expense figures match the donut palette

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30fdd430883248689dd28190a34ee