### PR TITLE
Refine distribution totals and add regression test

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -3403,7 +3403,6 @@ function computeDistributionTotals(details) {
       return;
     }
 
-    const gross = Math.max(toFiniteNumber(detail.gross_income), 0);
     const rawNet = toFiniteNumber(detail.net_income);
     let netIncomeValue = rawNet > 0 ? rawNet : 0;
 
@@ -3411,64 +3410,41 @@ function computeDistributionTotals(details) {
       detail.total_tax !== undefined && detail.total_tax !== null
         ? detail.total_tax
         : detail.tax;
-    let taxValue = Math.max(toFiniteNumber(taxCandidate), 0);
+    const taxValue = Math.max(toFiniteNumber(taxCandidate), 0);
 
-    const explicitContributionCandidates = [
-      toFiniteNumber(detail.employee_contributions),
-      toFiniteNumber(detail.deductible_contributions),
-      toFiniteNumber(detail.contributions),
-    ];
-    let insuranceValue = 0;
     let expenseValue = sumDetailFields(detail, DISTRIBUTION_EXPENSE_FIELDS);
-
     if (rawNet < 0) {
       expenseValue += Math.abs(rawNet);
       netIncomeValue = 0;
     }
 
-    if (gross > 0) {
-      const residual = gross - taxValue - netIncomeValue;
-      if (residual > 0.01) {
-        insuranceValue = residual;
-      } else if (residual > 0) {
-        insuranceValue = residual;
+    const contributionCandidates = [
+      toFiniteNumber(detail.employee_contributions),
+      toFiniteNumber(detail.deductible_contributions),
+      toFiniteNumber(detail.contributions),
+    ];
+    let insuranceValue = contributionCandidates.reduce((total, value) => {
+      return value > 0 ? total + value : total;
+    }, 0);
+
+    if (insuranceValue <= 0) {
+      const gross = Math.max(toFiniteNumber(detail.gross_income), 0);
+      if (gross > 0) {
+        const impliedInsurance =
+          gross - (taxValue + expenseValue + netIncomeValue);
+        if (impliedInsurance > 0) {
+          insuranceValue = impliedInsurance;
+        }
       }
     }
 
-    const explicitContribution = explicitContributionCandidates.reduce(
-      (max, value) => (value > max ? value : max),
-      0,
-    );
-    if (explicitContribution > 0 && explicitContribution > insuranceValue) {
-      insuranceValue = explicitContribution;
-    }
+    const computedGross =
+      Math.max(netIncomeValue, 0) +
+      Math.max(taxValue, 0) +
+      Math.max(insuranceValue, 0) +
+      Math.max(expenseValue, 0);
 
-    if (gross > 0) {
-      const allocated =
-        taxValue + insuranceValue + expenseValue + netIncomeValue;
-      const difference = gross - allocated;
-      if (difference > 0.01) {
-        netIncomeValue += difference;
-      } else if (difference < -0.01) {
-        let remaining = Math.abs(difference);
-
-        const reduceValue = (current) => {
-          if (current <= 0 || remaining <= 0) {
-            return current;
-          }
-          const reduction = Math.min(current, remaining);
-          remaining -= reduction;
-          return current - reduction;
-        };
-
-        insuranceValue = reduceValue(insuranceValue);
-        expenseValue = reduceValue(expenseValue);
-        taxValue = reduceValue(taxValue);
-        netIncomeValue = reduceValue(netIncomeValue);
-      }
-    }
-
-    grossTotal += gross;
+    grossTotal += computedGross;
     totals.net_income += Math.max(netIncomeValue, 0);
     totals.taxes += Math.max(taxValue, 0);
     totals.insurance += Math.max(insuranceValue, 0);

--- a/tests/frontend/computeDistributionTotals.test.js
+++ b/tests/frontend/computeDistributionTotals.test.js
@@ -1,0 +1,58 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadComputeDistributionTotals() {
+  const sourcePath = resolve(
+    __dirname,
+    '../../src/frontend/assets/scripts/main.js',
+  );
+  const source = readFileSync(sourcePath, 'utf8');
+  const snippetMatch = source.match(
+    /const DISTRIBUTION_EXPENSE_FIELDS[\s\S]*?function computeDistributionTotals[\s\S]*?return { totals, totalValue };\n}/,
+  );
+  if (!snippetMatch) {
+    throw new Error('Unable to load computeDistributionTotals from main.js');
+  }
+  const factory = new Function(`${snippetMatch[0]}; return computeDistributionTotals;`);
+  return factory();
+}
+
+test('computeDistributionTotals keeps insurance separate from expenses', () => {
+  const computeDistributionTotals = loadComputeDistributionTotals();
+  const detail = {
+    gross_income: 15000,
+    net_income: 6800,
+    total_tax: 3200,
+    employee_contributions: 2900,
+    deductible_contributions: 600,
+    deductible_expenses: 1000,
+  };
+
+  const { totals, totalValue } = computeDistributionTotals([detail]);
+
+  assert.ok(
+    totals.insurance > 0,
+    'insurance total should remain positive when contributions exist',
+  );
+  assert.equal(
+    totals.insurance,
+    detail.employee_contributions + detail.deductible_contributions,
+    'insurance total should equal explicit contributions',
+  );
+  assert.equal(
+    totals.expenses,
+    detail.deductible_expenses,
+    'expenses should remain isolated in their own slice',
+  );
+  assert.equal(
+    totalValue,
+    totals.net_income + totals.taxes + totals.insurance + totals.expenses,
+    'total value should match recomputed gross flows',
+  );
+});


### PR DESCRIPTION
## Summary
- update the distribution aggregation to derive gross totals from the sum of net income, taxes, contributions, and deductible expenses
- preserve insurance allocations when expenses are present by basing gross totals on the recomputed flows
- add a Node test that guards the freelance contributions plus expenses scenario

## Testing
- node --test tests/frontend/computeDistributionTotals.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e314e4aba08324a7d6c734faaf4a6b