### PR TITLE
Fix persistence of EFKA category selection

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -790,8 +790,8 @@ function preserveCurrentFormValues() {
   }
 
   pendingCalculatorState = {
-    ...(pendingCalculatorState || {}),
     ...snapshot,
+    ...(pendingCalculatorState || {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- ensure calculator state snapshots do not overwrite previously stored values when preserving fields, keeping EFKA category selection after refresh

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e319627fd883249075f3b45cb0829b