### PR TITLE
Refine demographics layout in calculator

### DIFF
--- a/src/frontend/assets/scripts/translations.generated.js
+++ b/src/frontend/assets/scripts/translations.generated.js
@@ -28,6 +28,7 @@
         },
         "results_heading": "Αποτελέσματα",
         "subheadings": {
+          "demographics": "Δημογραφικά στοιχεία",
           "pension": "Εισόδημα συντάξεων"
         }
       },
@@ -402,6 +403,7 @@
         },
         "results_heading": "Results",
         "subheadings": {
+          "demographics": "Demographic details",
           "pension": "Pension income"
         }
       },

--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -617,6 +617,10 @@ main {
   border-top: 1px solid var(--border-subtle);
 }
 
+.form-subsection + .form-grid.double {
+  margin-top: 1.35rem;
+}
+
 .fieldset-subheading {
   margin: 0 0 0.35rem;
   font-size: 1.05rem;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -216,60 +216,70 @@
                   disability).
                 </p>
               </div>
-              <div class="form-control">
-                <label for="birth-year" data-i18n-key="fields.birth-year">
-                  Birth year (optional)
-                </label>
-                <input
-                  id="birth-year"
-                  name="demographics.birth_year"
-                  type="number"
-                  min="1900"
-                  max="2100"
-                  step="1"
-                  aria-describedby="birth-year-hint"
-                />
-                <p
-                  id="birth-year-hint"
-                  class="form-hint"
-                  data-i18n-key="hints.birth-year"
-                >
-                  Add the taxpayer birth year to auto-calculate youth relief
-                  eligibility.
-                </p>
-              </div>
-              <div class="form-control">
-                <label for="age-band" data-i18n-key="fields.age-band">
-                  Youth relief age group
-                </label>
-                <select id="age-band" name="demographics.age_band">
-                  <option
-                    value=""
-                    data-i18n-key="fields.age-band-default"
+            </div>
+            <div class="form-subsection">
+              <h3
+                class="fieldset-subheading"
+                data-i18n-key="calculator.subheadings.demographics"
+              >
+                Demographic details
+              </h3>
+              <div class="form-grid double">
+                <div class="form-control">
+                  <label for="birth-year" data-i18n-key="fields.birth-year">
+                    Birth year (optional)
+                  </label>
+                  <input
+                    id="birth-year"
+                    name="demographics.birth_year"
+                    type="number"
+                    min="1900"
+                    max="2100"
+                    step="1"
+                    aria-describedby="birth-year-hint"
+                  />
+                  <p
+                    id="birth-year-hint"
+                    class="form-hint"
+                    data-i18n-key="hints.birth-year"
                   >
-                    Select age group (optional)
-                  </option>
-                  <option
-                    value="under_25"
-                    data-i18n-key="fields.age-band-under-25"
+                    Add the taxpayer birth year to auto-calculate youth relief
+                    eligibility.
+                  </p>
+                </div>
+                <div class="form-control">
+                  <label for="age-band" data-i18n-key="fields.age-band">
+                    Youth relief age group
+                  </label>
+                  <select id="age-band" name="demographics.age_band">
+                    <option
+                      value=""
+                      data-i18n-key="fields.age-band-default"
+                    >
+                      Select age group (optional)
+                    </option>
+                    <option
+                      value="under_25"
+                      data-i18n-key="fields.age-band-under-25"
+                    >
+                      Under 25 (youth rate)
+                    </option>
+                    <option
+                      value="age26_30"
+                      data-i18n-key="fields.age-band-26-30"
+                    >
+                      Age 26–30 entering workforce
+                    </option>
+                  </select>
+                  <p
+                    id="age-band-hint"
+                    class="form-hint"
+                    data-i18n-key="hints.age-band"
                   >
-                    Under 25 (youth rate)
-                  </option>
-                  <option
-                    value="age26_30"
-                    data-i18n-key="fields.age-band-26-30"
-                  >
-                    Age 26–30 entering workforce
-                  </option>
-                </select>
-                <p
-                  id="age-band-hint"
-                  class="form-hint"
-                  data-i18n-key="hints.age-band"
-                >
-                  Override the automatic youth band when the worker qualifies
-                  through special rules (for example, first-time employment).
-                </p>
+                    Override the automatic youth band when the worker qualifies
+                    through special rules (for example, first-time employment).
+                  </p>
+                </div>
               </div>
             </div>
             <div class="form-grid double">


### PR DESCRIPTION
## Summary
- move the birth year and age band inputs into a dedicated demographics subsection ahead of eligibility toggles
- add translations for the new demographics subheading in both supported locales
- adjust form spacing so the new subsection keeps clear separation from the relief toggles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e31f94c3348324b7f781b1121532aa