### PR TITLE
Reorder pension input controls

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1057,6 +1057,18 @@
             <div class="form-grid double">
               <div class="form-control">
                 <label
+                  for="pension-payments"
+                  data-i18n-key="fields.pension-payments"
+                >
+                  Pension payments per year
+                </label>
+                <select
+                  id="pension-payments"
+                  name="pension.payments_per_year"
+                ></select>
+              </div>
+              <div class="form-control">
+                <label
                   for="pension-mode"
                   data-i18n-key="fields.pension-mode"
                 >
@@ -1076,18 +1088,6 @@
                     Enter gross amount per payment
                   </option>
                 </select>
-              </div>
-              <div class="form-control">
-                <label
-                  for="pension-payments"
-                  data-i18n-key="fields.pension-payments"
-                >
-                  Pension payments per year
-                </label>
-                <select
-                  id="pension-payments"
-                  name="pension.payments_per_year"
-                ></select>
               </div>
               <div
                 class="form-control"


### PR DESCRIPTION
## Summary
- reorder the pension payments and mode selectors so the payments dropdown appears first while keeping inputs under their controlling selector
- verified that pension mode toggling logic continues to target the relocated elements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e31fa277488324a2a413c3c1561419