### PR TITLE
Ensure site header renders in print layout

### DIFF
--- a/src/frontend/assets/styles/main.css
+++ b/src/frontend/assets/styles/main.css
@@ -1559,10 +1559,6 @@ main {
   background: var(--flow-net);
 }
 
-.no-print {
-  /* Utility class to hide sections in print layout */
-}
-
 @media (min-width: 768px) {
   .site-header {
     text-align: left;
@@ -2047,8 +2043,7 @@ main {
   .results-visualisation,
   #sankey-wrapper,
   #distribution-wrapper,
-  .distribution-card,
-  .no-print {
+  .distribution-card {
     display: none !important;
   }
 

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="./assets/styles/main.css" />
   </head>
   <body>
-    <header class="site-header no-print">
+    <header class="site-header">
       <div class="site-header__inner">
         <div class="site-header__topbar">
           <div class="site-branding">


### PR DESCRIPTION
## Summary
- remove the `no-print` utility class from the site header so it displays in printed output
- tighten the print stylesheet selectors now that `.no-print` is unused

## Testing
- manual print preview via Playwright (`print-view.png`)


------
https://chatgpt.com/codex/tasks/task_e_68e37e8624f08324bdf4e7d6853fcbac