### PR TITLE
Deduplicate employment advanced controls

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -627,32 +627,6 @@
                   </div>
                 </details>
               </div>
-              <div class="form-control">
-                <label
-                  for="employment-withholding"
-                  data-i18n-key="fields.employment-withholding"
-                >
-                  Tax already withheld (PAYE) (€)
-                </label>
-                <input
-                  id="employment-withholding"
-                  name="withholding_tax"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value="0"
-                  aria-describedby="employment-withholding-hint"
-                />
-                <p
-                  id="employment-withholding-hint"
-                  class="form-hint"
-                  data-static-hint="true"
-                  data-i18n-key="hints.employment-withholding"
-                >
-                  Enter PAYE income tax already withheld on payslips to offset the
-                  balance due.
-                </p>
-              </div>
               <div
                 class="form-control"
                 data-section="employment"
@@ -737,63 +711,6 @@
                   Enter PAYE income tax already withheld on payslips to offset the
                   balance due.
                 </p>
-              </div>
-              <div class="form-control form-control--advanced">
-                <details class="help-panel">
-                  <summary data-i18n-key="ui.advanced_options">
-                    Advanced options
-                  </summary>
-                  <div class="form-control form-control--nested">
-                    <label
-                      for="employment-employee-contributions"
-                      data-i18n-key="fields.employment-employee-contributions"
-                    >
-                      Employee EFKA contributions (outside payroll) (€)
-                    </label>
-                    <input
-                      id="employment-employee-contributions"
-                      name="employment.employee_contributions"
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value="0"
-                      aria-describedby="employment-employee-contributions-hint"
-                    />
-                    <p
-                      id="employment-employee-contributions-hint"
-                      class="form-hint"
-                      data-i18n-key="hints.employment-employee-contributions"
-                    >
-                      Add EFKA amounts you pay directly outside payroll (for example, voluntary top-ups). Most
-                      employees will leave this at 0 because payroll already covers EFKA.
-                    </p>
-                  </div>
-                  <div class="form-control form-control--nested">
-                    <span class="inline-field">
-                      <input
-                        id="employment-include-social"
-                        name="employment.include_social_contributions"
-                        type="checkbox"
-                        checked
-                        aria-describedby="employment-include-social-hint"
-                      />
-                      <label
-                        for="employment-include-social"
-                        data-i18n-key="fields.employment-include-social"
-                      >
-                        Include social insurance contributions in net pay
-                      </label>
-                    </span>
-                    <p
-                      id="employment-include-social-hint"
-                      class="form-hint"
-                      data-i18n-key="hints.employment-include-social"
-                    >
-                      Uncheck to see tax-only net income. EFKA amounts (employee and employer) will be treated as
-                      zero in the results.
-                    </p>
-                  </div>
-                </details>
               </div>
             </div>
             <p


### PR DESCRIPTION
## Summary
- remove the duplicate advanced options panel from the employment fieldset
- keep a single tax withholding input alongside the annual and monthly controls

## Testing
- python - <<'PY'  # duplicate id check


------
https://chatgpt.com/codex/tasks/task_e_68e37e7d36688324894768db6adef866