### PR TITLE
Add documentation audit tracker and style guide references

### DIFF
--- a/docs/documentation_audit.md
+++ b/docs/documentation_audit.md
@@ -1,0 +1,16 @@
+# Documentation Audit – 2024-05-19
+
+## Scope
+Inventory of README.md, Requirements.md, and documentation under docs/ to flag overlapping or outdated sections that need consolidation or revision.
+
+## Findings
+| Document | Section | Status | Notes | Suggested action |
+| --- | --- | --- | --- | --- |
+| README.md | Architecture Overview | Overlapping | Restates module boundary details already captured in docs/architecture.md without referencing that source. | Trim README summary to a high-level blurb and link directly to docs/architecture.md for deep dives. |
+| README.md | Refreshing front-end translations | Overlapping | Repeats the end-to-end workflow maintained in docs/i18n.md. Minor divergences (e.g., phrasing) create drift risk. | Replace with a short pointer to docs/i18n.md so the workflow lives in a single location. |
+| README.md | Performance Snapshot | Overlapping | Mirrors guidance from docs/performance_baseline.md. Divergent command formatting (“python …” vs executable script) could confuse contributors. | Consolidate instructions under docs/performance_baseline.md and keep README to a brief teaser + link. |
+| docs/architecture.md | Deployment Interaction | Overlapping | Duplicates API base-switch guidance later repeated in README.md (“Configuring the API endpoint”). | Decide which doc owns deployment toggle instructions; cross-link the other to avoid drift. |
+| docs/project_plan.md | Documentation references | Outdated | Plan does not yet reference the new documentation audit/style baseline maintainers should follow. | Add links to docs/documentation_audit.md and docs/documentation_style.md in the planning overview so future updates use the shared baseline. |
+
+## Next Review
+Re-evaluate after consolidating the duplicated sections or when major architectural shifts land to ensure the canonical sources stay aligned.

--- a/docs/documentation_style.md
+++ b/docs/documentation_style.md
@@ -1,0 +1,33 @@
+# Documentation Style & Voice Guide
+
+## Purpose
+Provide a shared reference for contributors updating README.md, Requirements.md, and files in docs/ so that future documentation changes follow consistent structure, tone, and referencing.
+
+## Headings
+- Use sentence case for section headings (capitalise only the first word and proper nouns) to match the current documentation refresh.
+- Keep top-level documents under 3 heading levels where possible; prefer concise subsections over deeply nested hierarchies.
+- Begin documents with an H1 that states the artifact’s role (e.g., “Documentation audit” or “Internationalisation workflow”).
+
+## Voice & Tone
+- Write in an instructive, confident voice that focuses on practical steps and rationale.
+- Prefer present tense and direct language (e.g., “Run the script” instead of “You should run the script”).
+- When describing future work, indicate ownership and expected outcome to keep backlog notes actionable.
+
+## Localisation Callouts
+- Note when instructions differ for Greek versus English audiences or when bilingual assets must be updated; use inline callouts like “(update both `en` and `el` catalogues)” rather than lengthy prose.
+- Reference localisation workflows via docs/i18n.md unless new behaviour is being introduced; avoid re-explaining the pipeline in multiple places.
+- Highlight UI copy changes with locale tags or key names so translators can find the relevant strings quickly.
+
+## Command & Code Formatting
+- Use fenced code blocks with an explicit language identifier (```` ```bash ```` for shell commands, ```` ```python ```` for Python snippets).
+- Show full commands, including `python` or environment variables, to prevent ambiguity across operating systems.
+- When commands span multiple steps, keep them in execution order and avoid inline ellipses that obscure required flags.
+
+## Citations & References
+- When citing repository files or code locations, use the `【F:<path>†L<start>-L<end>】` pattern to align with project and tooling conventions.
+- For command output captured during testing, reference the terminal chunk ID with `【<chunk_id>†L<start>-L<end>】`.
+- Link to canonical documents (e.g., architecture, i18n workflow) instead of duplicating large explanations; cite them when summarising behaviour.
+
+## Review & Maintenance
+- Update this guide whenever documentation conventions change (e.g., adopting a different heading style or citation format).
+- Cross-reference updates in docs/project_plan.md so sprint notes and future contributors are aware of the latest baseline.

--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -6,6 +6,12 @@ tool for individuals in Greece. The project prioritises accuracy, clarity, and
 maintainability. Development will proceed iteratively using epics and sprints to
 deliver user value in incremental, testable slices.
 
+## Documentation baseline
+- Track overlapping or outdated guidance in [docs/documentation_audit.md](./documentation_audit.md) before touching shared
+  docs so updates target the canonical source.
+- Follow the conventions in [docs/documentation_style.md](./documentation_style.md) when drafting or revising
+  documentation across the repository.
+
 ## Epics Overview
 
 1. **Core Tax Engine**


### PR DESCRIPTION
## Summary
- add docs/documentation_audit.md to record overlapping or outdated guidance across README.md, Requirements.md, and docs/
- create docs/documentation_style.md to standardise headings, tone, localisation callouts, command formatting, and citation practices
- update docs/project_plan.md to point maintainers at the new audit and style guide for future documentation work

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3b2fbb5f88324a4aeabdaa24ebed7