### PR TITLE
Document operational workflow index and cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,20 @@ The script rebuilds
 file so static deployments remain in sync with the canonical catalogues. See
 [`docs/i18n.md`](docs/i18n.md) for end-to-end localisation guidance.
 
+## Development Environment
+
+Use the [Operational Workflows Index](docs/operations.md) as the entry point for
+recurring contributor tasks. It summarises localisation updates, performance
+baseline captures, and UI review loops with links to the detailed guides.
+
 ## Architecture & Planning References
 
 - [`docs/architecture.md`](docs/architecture.md) — module boundaries, deployment
   model, and maintenance workflows.
 - [`docs/project_plan.md`](docs/project_plan.md) — roadmap, sprint history, and
   upcoming milestones.
-- [`docs/i18n.md`](docs/i18n.md) — localisation workflows and translation
-  catalogue conventions.
+- [`docs/operations.md`](docs/operations.md) — index of localisation,
+  performance, and UI review workflows.
 - [`Requirements.md`](Requirements.md) — product requirements and acceptance
   criteria.
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -52,7 +52,10 @@ falls back to the `en` catalogue whenever a requested key or locale is missing.
    pytest
    ```
 
-4. Commit the updated JSON files, generated bundle, and any accompanying tests
+4. If the update introduces large batches of strings or media references, rerun
+   the performance snapshot to capture any bundle-size or render-time impact.
+   See [`docs/performance_baseline.md`](performance_baseline.md) for details.
+5. Commit the updated JSON files, generated bundle, and any accompanying tests
    or documentation.
 
 ## Adding a New Language
@@ -77,7 +80,11 @@ falls back to the `en` catalogue whenever a requested key or locale is missing.
    pytest
    ```
 
-6. Commit the new catalogue, generated bundle, and any UI updates.
+6. When introducing a new locale, schedule a UI review to confirm layouts still
+   accommodate translated copy. Use the guidance in
+   [`docs/ui_improvement_plan.md`](ui_improvement_plan.md) to document and track
+   any follow-up polish.
+7. Commit the new catalogue, generated bundle, and any UI updates.
 
 ## Verifying API Responses
 
@@ -104,3 +111,11 @@ The response should contain the translated strings you just added or modified.
 
 Following this process keeps translations aligned across the stack and minimises
 manual synchronisation effort.
+
+## Related Workflows
+
+- [`docs/performance_baseline.md`](performance_baseline.md) – capture new
+  performance baselines after large catalogue batches or when localisation
+  changes affect bundle sizes.
+- [`docs/ui_improvement_plan.md`](ui_improvement_plan.md) – verify visual polish
+  and layout integrity when translated copy or locale toggles evolve.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,32 @@
+# Operational Workflows Index
+
+Centralise the day-to-day workflows that keep GreekTax healthy. Each guide
+provides detailed steps, but this index outlines when to use them and how they
+connect so contributors can plan multi-disciplinary changes without surprises.
+
+## Localisation Updates
+- **When to use**: Any time copy changes are required or new locales are
+  introduced.
+- **Key actions**: Update the JSON catalogues, rebuild the embedded bundle, and
+  verify API responses and UI previews.
+- **Stay aligned**: Large catalogue updates can impact render timings and
+  bundle sizes—schedule a follow-up performance snapshot to capture the delta.
+- **Full workflow**: [`docs/i18n.md`](i18n.md)
+
+## Performance Baselines
+- **When to use**: After feature work that changes calculations, asset bundles,
+  or localisation payloads.
+- **Key actions**: Run `scripts/performance_snapshot.py`, compare trends, and
+  update tracking dashboards as needed.
+- **Stay aligned**: Coordinate with the localisation workflow when large copy
+  batches land and with UI reviews when visual refinements grow asset payloads.
+- **Full workflow**: [`docs/performance_baseline.md`](performance_baseline.md)
+
+## UI Review Loops
+- **When to use**: During visual refresh sprints or any change that adjusts the
+  presentation layer.
+- **Key actions**: Apply design tokens, validate accessibility, and capture
+  review notes for future iterations.
+- **Stay aligned**: Account for new localisation strings in layouts and rerun
+  performance snapshots if asset budgets shift.
+- **Full workflow**: [`docs/ui_improvement_plan.md`](ui_improvement_plan.md)

--- a/docs/performance_baseline.md
+++ b/docs/performance_baseline.md
@@ -4,7 +4,9 @@ Sprint 18 introduces lightweight tooling for tracking calculation timings,
 front-end bundle sizes, and accessibility metadata so the team can monitor
 optimisation work over time. The `scripts/performance_snapshot.py` helper wraps
 the back-end calculation service, inspects critical static assets, and scans the
-HTML shell for ARIA usage.
+HTML shell for ARIA usage. Use this workflow alongside localisation and UI
+reviews so that catalogue or styling changes are reflected in the historical
+baseline.
 
 ## Running the snapshot
 
@@ -43,4 +45,14 @@ The calculation timings rely on the profiling hooks in
 variable `GREEKTAX_PROFILE_CALCULATIONS=true` prints per-section timings for
 ad-hoc investigations while keeping the API contract unchanged. The snapshot now
 reports minimum and maximum iteration durations to surface jitter alongside the
-average and cumulative timings.
+average and cumulative timings. After significant localisation batches or UI
+refresh work, coordinate reruns with the
+[`docs/i18n.md`](i18n.md) and [`docs/ui_improvement_plan.md`](ui_improvement_plan.md)
+workflows so bundle and render changes stay measurable.
+
+## Related Workflows
+
+- [`docs/i18n.md`](i18n.md) – localisation guidance for catalogue updates that
+  often precede performance sampling.
+- [`docs/ui_improvement_plan.md`](ui_improvement_plan.md) – UI polish checklist
+  that may influence asset payloads and accessibility metrics captured here.

--- a/docs/ui_improvement_plan.md
+++ b/docs/ui_improvement_plan.md
@@ -87,11 +87,15 @@ polish.
 
 ## Dependencies & Risks
 - Localisation updates may require coordination with translators for new highlight
-  copy and legend descriptions.
+  copy and legend descriptions. Follow the
+  [`docs/i18n.md`](i18n.md) workflow so copy and bundle regeneration stay in
+  sync with layout changes.
 - Plotly configuration changes must stay compatible with backend data shapes to
   avoid runtime chart errors.
 - Accessibility tooling (e.g., axe) should be rerun after visual updates to guard
-  against colour contrast regressions.
+  against colour contrast regressions, and the
+  [`docs/performance_baseline.md`](performance_baseline.md) workflow should be
+  exercised if asset sizes or render paths shift.
 
 ## Out of Scope
 - Introducing a dark theme or advanced animation sequencing (tracked for future
@@ -103,3 +107,10 @@ polish.
 1. GreekTax Requirements – non-functional visual communication guidance.【F:Requirements.md†L96-L111】
 2. Front-end localisation catalogue for hero and Sankey copy.【F:src/frontend/assets/scripts/main.js†L20-L118】【F:src/frontend/assets/scripts/main.js†L241-L339】
 3. Current Sankey rendering implementation for refinement baseline.【F:src/frontend/assets/scripts/main.js†L2079-L2350】
+
+## Related Workflows
+
+- [`docs/i18n.md`](i18n.md) – manage translation updates required for hero and
+  navigation copy.
+- [`docs/performance_baseline.md`](performance_baseline.md) – reprofile asset
+  bundles and render timings after visual polish work.


### PR DESCRIPTION
## Summary
- add an operational workflows index that summarises localisation, performance, and UI review guides
- cross-link localisation, performance, and UI documentation so teams know when to coordinate workstreams
- surface the new entry point from the README development environment guidance

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3bc18cdc08324a8dd64db0cead442