### PR TITLE
Add employer cost reporting to employment income details

### DIFF
--- a/src/greektax/backend/app/models/__init__.py
+++ b/src/greektax/backend/app/models/__init__.py
@@ -378,6 +378,14 @@ class GeneralIncomeComponent:
             return None
         return self.gross_income / self.payments_per_year
 
+    def employer_cost(self) -> float:
+        return self.gross_income + self.employer_contributions
+
+    def employer_cost_per_payment(self) -> float | None:
+        if not self.payments_per_year or self.payments_per_year <= 0:
+            return None
+        return self.employer_cost() / self.payments_per_year
+
 
 @dataclass(slots=True)
 class DetailTotals:

--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -558,6 +558,14 @@ def _add_employment_contribution_fields(
                 component.employer_contributions / component.payments_per_year
             )
 
+    if component.category == "employment":
+        detail["employer_cost"] = round_currency(component.employer_cost())
+        employer_cost_per_payment = component.employer_cost_per_payment()
+        if employer_cost_per_payment is not None:
+            detail["employer_cost_per_payment"] = round_currency(
+                employer_cost_per_payment
+            )
+
 
 def _add_freelance_fields(
     detail: dict[str, Any], component: GeneralIncomeComponent, translator: Translator

--- a/src/greektax/translations/el.json
+++ b/src/greektax/translations/el.json
@@ -116,6 +116,8 @@
       "employee_contributions_per_payment": "Εισφορές εργαζομένου ανά καταβολή",
       "employer_contributions": "Εισφορές εργοδότη",
       "employer_contributions_per_payment": "Εισφορές εργοδότη ανά καταβολή",
+      "employer_cost": "Κόστος εργοδότη",
+      "employer_cost_per_payment": "Κόστος εργοδότη ανά καταβολή",
       "gross_income": "Ακαθάριστο εισόδημα",
       "gross_income_per_payment": "Ακαθάριστο ανά καταβολή",
       "lump_sum_contributions": "Εισφορές εφάπαξ",

--- a/src/greektax/translations/en.json
+++ b/src/greektax/translations/en.json
@@ -116,6 +116,8 @@
       "employee_contributions_per_payment": "Employee contributions per payment",
       "employer_contributions": "Employer contributions",
       "employer_contributions_per_payment": "Employer contributions per payment",
+      "employer_cost": "Employer cost",
+      "employer_cost_per_payment": "Employer cost per payment",
       "gross_income": "Gross income",
       "gross_income_per_payment": "Gross per payment",
       "lump_sum_contributions": "Lump-sum fund contributions",


### PR DESCRIPTION
## Summary
- compute employer cost totals for employment income details, including per-payment values when applicable
- add English and Greek i18n labels for the new employer cost fields
- expand unit tests to validate employer cost output across contribution scenarios

## Testing
- pytest tests/unit/test_calculation_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c517419083248ccd22300e127c41