### PR TITLE
Fix salary credit reduction fallback for derived income

### DIFF
--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -255,8 +255,6 @@ def _apply_progressive_tax(
             declared_total += payload.pension_declared_gross_income
         if declared_total > 0:
             salary_credit_income = declared_total
-        else:
-            salary_credit_income = 0.0
     credit_reduction = 0.0
     if salary_credit_income > 12_000:
         credit_reduction = ((salary_credit_income - 12_000) / 1_000) * 20.0

--- a/tests/unit/test_calculation_service.py
+++ b/tests/unit/test_calculation_service.py
@@ -457,6 +457,40 @@ def test_employment_tax_credit_reduced_using_gross_income() -> None:
     assert employment_detail["credits"] >= 0.0
 
 
+def test_salary_credit_reduction_uses_derived_income_when_no_declared() -> None:
+    """Monthly salary inputs still reduce the credit when above the threshold."""
+
+    request = CalculationRequest.model_validate(
+        {
+            "year": 2024,
+            "dependents": {"children": 0},
+            "employment": {
+                "monthly_income": 2_000,
+                "payments_per_year": 14,
+            },
+        }
+    )
+
+    result = calculate_tax(request)
+    employment_detail = result["details"][0]
+
+    config = load_year_configuration(request.year)
+    base_credit = config.employment.tax_credit.amount_for_children(
+        request.dependents.children
+    )
+
+    monthly_income = request.employment.monthly_income or 0.0
+    payments_per_year = request.employment.payments_per_year or 0
+    derived_income = monthly_income * payments_per_year
+    assert derived_income > 12_000
+
+    reduction = ((derived_income - 12_000) / 1_000) * 20.0
+    expected_credit = max(base_credit - reduction, 0.0)
+
+    assert employment_detail["credits"] == pytest.approx(expected_credit)
+    assert employment_detail["credits"] >= 0.0
+
+
 def test_calculate_tax_with_withholding_tax_balance_due() -> None:
     """Withholding reduces the net tax payable and surfaces in the summary."""
 


### PR DESCRIPTION
## Summary
- keep the salary tax credit reduction base aligned with derived income when no declared totals are provided for pre-2025 years
- add a regression test to cover salary credit reduction with monthly-only employment inputs

## Testing
- pytest tests/unit/test_calculation_service.py::test_salary_credit_reduction_uses_derived_income_when_no_declared

------
https://chatgpt.com/codex/tasks/task_e_68e3d485c59883248ec9ff10e9999be0