### PR TITLE
Fix salary credit reduction for derived income

### DIFF
--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -255,8 +255,6 @@ def _apply_progressive_tax(
             declared_total += payload.pension_declared_gross_income
         if declared_total > 0:
             salary_credit_income = declared_total
-        else:
-            salary_credit_income = 0.0
     credit_reduction = 0.0
     if salary_credit_income > 12_000:
         credit_reduction = ((salary_credit_income - 12_000) / 1_000) * 20.0

--- a/tests/data/regression_scenarios.json
+++ b/tests/data/regression_scenarios.json
@@ -157,18 +157,18 @@
     "expectations": {
       "summary": {
         "income_total": 25900.0,
-        "tax_total": 2969.15,
-        "net_income": 19338.52,
-        "average_monthly_tax": 247.43
+        "tax_total": 3247.15,
+        "net_income": 19060.52,
+        "average_monthly_tax": 270.6
       },
       "details": {
         "employment": {
           "tax_before_credits": 3746.15,
-          "credits": 777.0,
-          "total_tax": 2969.15,
+          "credits": 499.0,
+          "total_tax": 3247.15,
           "payments_per_year": 14,
           "gross_income_per_payment": 1850.0,
-          "net_income_per_payment": 1381.32
+          "net_income_per_payment": 1361.47
         }
       }
     }


### PR DESCRIPTION
## Summary
- restore use of derived salary income for tax credit reduction when declared totals are absent
- update regression fixtures and expectations to reflect the reduced credit for monthly employment income
- adjust unit helpers to derive the reduction base from monthly inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e9edb06c8324b158242045bbbd9c