### PR TITLE
Fix 2026 large family tax credit reduction

### DIFF
--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -259,8 +259,17 @@ def _apply_progressive_tax(
     if salary_credit_income > 12_000:
         credit_reduction = ((salary_credit_income - 12_000) / 1_000) * 20.0
 
+    reduction_exempt_from = (
+        config.employment.tax_credit.income_reduction_exempt_from_dependants
+    )
+
     def _credit_after_reduction(credit: float) -> float:
         if credit_reduction <= 0:
+            return credit
+        if (
+            reduction_exempt_from is not None
+            and payload.children >= reduction_exempt_from
+        ):
             return credit
         reduced = credit - credit_reduction
         if reduced < 0:

--- a/src/greektax/backend/config/data/2026.yaml
+++ b/src/greektax/backend/config/data/2026.yaml
@@ -219,6 +219,7 @@ income:
         "14": 3760
         "15": 3980
       incremental_amount_per_child: 220
+      income_reduction_exempt_from_dependants: 5
       pending_confirmation: true
     family_tax_credit:
       pending_confirmation: true

--- a/src/greektax/backend/config/year_config.py
+++ b/src/greektax/backend/config/year_config.py
@@ -140,6 +140,7 @@ class EmploymentTaxCredit:
     incremental_amount_per_child: float
     pending_confirmation: bool = False
     estimate: bool = False
+    income_reduction_exempt_from_dependants: int | None = None
 
     def amount_for_children(self, dependants: int) -> float:
         """Return the tax credit amount for the provided dependant count."""
@@ -632,6 +633,15 @@ def _parse_tax_credit(raw: Mapping[str, Any]) -> EmploymentTaxCredit:
         amounts[child_count] = float(value)
 
     incremental = float(raw.get("incremental_amount_per_child", 0.0))
+    reduction_exempt_raw = raw.get("income_reduction_exempt_from_dependants")
+    if reduction_exempt_raw is None:
+        reduction_exempt = None
+    else:
+        reduction_exempt = int(reduction_exempt_raw)
+        if reduction_exempt < 0:
+            raise ConfigurationError(
+                "'income_reduction_exempt_from_dependants' must be non-negative"
+            )
     pending = _parse_boolean_flag(
         raw.get("pending_confirmation"),
         context="employment.tax_credit 'pending_confirmation'",
@@ -646,6 +656,7 @@ def _parse_tax_credit(raw: Mapping[str, Any]) -> EmploymentTaxCredit:
         incremental_amount_per_child=incremental,
         pending_confirmation=pending,
         estimate=estimate,
+        income_reduction_exempt_from_dependants=reduction_exempt,
     )
 
 

--- a/tests/unit/test_calculation_service.py
+++ b/tests/unit/test_calculation_service.py
@@ -239,6 +239,33 @@ def test_2025_employment_youth_large_family_alignment() -> None:
     assert employment_detail["credits"] == pytest.approx(620.0)
 
 
+def test_2026_large_family_credit_not_reduced() -> None:
+    """Five-child households retain the full 2026 family tax credit despite income."""
+
+    request = build_request(
+        {
+            "year": 2026,
+            "dependents": {"children": 5},
+            "employment": {
+                "gross_income": 70_000,
+                "include_social_contributions": False,
+            },
+        }
+    )
+
+    result = calculate_tax(request)
+
+    summary = result["summary"]
+    employment_detail = next(
+        detail for detail in result["details"] if detail["category"] == "employment"
+    )
+
+    assert employment_detail["tax_before_credits"] == pytest.approx(17_200.0)
+    assert employment_detail["credits"] == pytest.approx(1_780.0)
+    assert employment_detail["total_tax"] == pytest.approx(15_420.0)
+    assert summary["net_income"] == pytest.approx(54_580.0)
+
+
 def _freelance_expectations(request: CalculationRequest) -> dict[str, Any]:
     """Return expected freelance and employment metrics for the mixed payload."""
 


### PR DESCRIPTION
## Summary
- add configuration support for exempting large families from the income-based reduction of the employment tax credit
- update the 2026 tax credit ladder to skip reductions when at least five dependent children are declared
- add a regression test mirroring the ministry calculator outcome for a five-child household in 2026

## Testing
- pytest tests/unit/test_calculation_service.py::test_2026_large_family_credit_not_reduced
- PYTHONPATH=src python -m greektax.backend.config.validator

------
https://chatgpt.com/codex/tasks/task_e_68e3ee21d4d08324b87eb064f2972592