### PR TITLE
Extend youth relief to 2026 freelance and agricultural incomes

### DIFF
--- a/src/greektax/backend/app/services/calculators/general_income.py
+++ b/src/greektax/backend/app/services/calculators/general_income.py
@@ -211,12 +211,15 @@ def _apply_progressive_tax(
     else:
         dependants = payload.children if payload.children > 0 else 0
         youth_category = payload.youth_rate_category
+        youth_relief_categories = {"employment"}
+        if config.year >= 2026:
+            youth_relief_categories.update({"freelance", "agricultural"})
 
         def _resolve_rate(index: int, bracket) -> float:
             component = components[index]
             if isinstance(bracket, MultiRateBracket):
                 if (
-                    component.category == "employment"
+                    component.category in youth_relief_categories
                     and youth_category
                     and youth_category in bracket.youth_rates
                 ):


### PR DESCRIPTION
## Summary
- allow 2026 youth relief rates to apply when the progressive tax component is freelance or agricultural
- add unit coverage confirming freelance and agricultural income receive the reduced 2026 youth bands

## Testing
- pytest tests/unit/test_calculation_service.py::test_2026_youth_relief_applies_to_freelance_income -q
- pytest tests/unit/test_calculation_service.py::test_2026_youth_relief_applies_to_agricultural_income -q
- pytest tests/unit/test_calculation_service.py::test_2026_youth_relief_second_band_matches_announced_rates -q


------
https://chatgpt.com/codex/tasks/task_e_68e44fd2b9788324b95be040be412604