### PR TITLE
Restrict CORS configuration via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ The script rebuilds
 file so static deployments remain in sync with the canonical catalogues. See
 [`docs/i18n.md`](docs/i18n.md) for end-to-end localisation guidance.
 
+### 4. Configure cross-origin access
+
+The API enforces an allow-list for browser origins via the
+`GREEKTAX_ALLOWED_ORIGINS` environment variable. Set it to a comma-separated
+list before running the server so front-end deployments can call the API:
+
+```bash
+export GREEKTAX_ALLOWED_ORIGINS="http://localhost:5173"
+flask --app greektax.backend.app:create_app run
+```
+
+- **Staging**: include the staging UI origin alongside any developer domains,
+  e.g. `GREEKTAX_ALLOWED_ORIGINS="http://localhost:5173,https://staging.tax.example"`.
+- **Production**: restrict the list to the public domain that serves the UI,
+  e.g. `GREEKTAX_ALLOWED_ORIGINS="https://app.tax.example"`.
+
+If the variable is unset or empty, cross-origin requests are rejected for both
+the Flask-Cors integration and the built-in fallback.
+
 ## Development Environment
 
 Use the [Operational Workflows Index](docs/operations.md) as the entry point for

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -1,31 +1,85 @@
 """Integration tests covering CORS behaviour for API endpoints."""
 
+import pytest
 from flask.testing import FlaskClient
 
+from greektax.backend.app import create_app
 
-def test_config_years_endpoint_includes_cors_headers(client: FlaskClient) -> None:
-    """Ensure cross-origin requests are permitted for public configuration data."""
+ALLOWED_ORIGIN = "https://allowed.test"
+ALLOWED_EMBEDDER = "https://embedder.test"
+DISALLOWED_ORIGIN = "https://blocked.test"
 
-    response = client.get(
+
+@pytest.fixture()
+def cors_client(monkeypatch: pytest.MonkeyPatch) -> FlaskClient:
+    """Return a client configured with a known CORS allow-list."""
+
+    monkeypatch.setenv(
+        "GREEKTAX_ALLOWED_ORIGINS",
+        ",".join([ALLOWED_ORIGIN, ALLOWED_EMBEDDER]),
+    )
+
+    app = create_app()
+    app.config.update(TESTING=True)
+
+    with app.test_client() as client:
+        yield client
+
+
+def test_config_years_endpoint_includes_cors_headers(
+    cors_client: FlaskClient,
+) -> None:
+    """Ensure cross-origin requests are permitted for configured origins."""
+
+    response = cors_client.get(
         "/api/v1/config/years",
-        headers={"Origin": "https://example.com"},
+        headers={"Origin": ALLOWED_ORIGIN},
     )
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "https://example.com"
+    assert response.headers.get("Access-Control-Allow-Origin") == ALLOWED_ORIGIN
 
 
-def test_preflight_request_returns_success(client: FlaskClient) -> None:
-    """Preflight checks should succeed so embedders can call the API."""
+def test_preflight_request_returns_success(cors_client: FlaskClient) -> None:
+    """Preflight checks should succeed for allowed origins."""
 
-    response = client.options(
+    response = cors_client.options(
         "/api/v1/config/years",
         headers={
-            "Origin": "https://embedder.test",
+            "Origin": ALLOWED_EMBEDDER,
             "Access-Control-Request-Method": "GET",
         },
     )
 
     assert response.status_code == 200
-    assert response.headers.get("Access-Control-Allow-Origin") == "https://embedder.test"
+    assert response.headers.get("Access-Control-Allow-Origin") == ALLOWED_EMBEDDER
     assert "GET" in response.headers.get("Access-Control-Allow-Methods", "")
+
+
+def test_disallowed_origin_does_not_receive_cors_headers(
+    cors_client: FlaskClient,
+) -> None:
+    """Origins outside the allow-list should not receive CORS access."""
+
+    response = cors_client.get(
+        "/api/v1/config/years",
+        headers={"Origin": DISALLOWED_ORIGIN},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") is None
+
+
+def test_disallowed_origin_preflight_is_rejected(cors_client: FlaskClient) -> None:
+    """Preflight requests from disallowed origins should not succeed."""
+
+    response = cors_client.options(
+        "/api/v1/config/years",
+        headers={
+            "Origin": DISALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code in (200, 403)
+    assert response.headers.get("Access-Control-Allow-Origin") is None


### PR DESCRIPTION
## Summary
- load the CORS allow-list for the API from the GREEKTAX_ALLOWED_ORIGINS environment variable
- harden the manual CORS fallback to reject origins outside the allow-list and document deployment guidance
- extend integration coverage to exercise both allowed and disallowed origins

## Testing
- pytest tests/integration/test_cors.py


------
https://chatgpt.com/codex/tasks/task_e_68e4c3345e508324a8c7aff21c897e8e