### PR TITLE
feat: allow static deployments to configure API base

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -9,9 +9,55 @@
 const REMOTE_API_BASE = "https://cntanos.pythonanywhere.com/api/v1";
 const LOCAL_API_BASE = "/api/v1";
 
-// Default to the remote API; toggle the line below for local development.
-const API_BASE = REMOTE_API_BASE;
-// const API_BASE = LOCAL_API_BASE; // Uncomment to use the local API during development.
+function resolveApiBase() {
+  const defaultBase = REMOTE_API_BASE;
+
+  if (typeof window === "undefined") {
+    return LOCAL_API_BASE;
+  }
+
+  const windowOverride =
+    typeof window.GREEKTAX_API_BASE === "string"
+      ? window.GREEKTAX_API_BASE.trim()
+      : "";
+  if (windowOverride) {
+    return windowOverride;
+  }
+
+  const documentRef = window.document || null;
+  const metaElement =
+    documentRef && documentRef.querySelector
+      ? documentRef.querySelector("meta[data-api-base]")
+      : null;
+  if (metaElement) {
+    const metaOverride =
+      typeof metaElement.dataset?.apiBase === "string"
+        ? metaElement.dataset.apiBase.trim()
+        : (metaElement.getAttribute("data-api-base") || "").trim();
+    if (metaOverride) {
+      return metaOverride;
+    }
+  }
+
+  const locationRef = window.location || null;
+  if (locationRef) {
+    const hostname = typeof locationRef.hostname === "string"
+      ? locationRef.hostname.trim().toLowerCase()
+      : "";
+    if (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost")
+    ) {
+      return LOCAL_API_BASE;
+    }
+  }
+
+  return defaultBase;
+}
+
+const API_BASE = resolveApiBase();
 const CALCULATIONS_ENDPOINT = `${API_BASE}/calculations`;
 const CONFIG_YEARS_ENDPOINT = `${API_BASE}/config/years`;
 const CONFIG_META_ENDPOINT = `${API_BASE}/config/meta`;

--- a/tests/frontend/apiBaseResolution.test.js
+++ b/tests/frontend/apiBaseResolution.test.js
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadResolver() {
+  const sourcePath = resolve(
+    __dirname,
+    '../../src/frontend/assets/scripts/main.js',
+  );
+  const source = readFileSync(sourcePath, 'utf8');
+
+  const remoteLine = source.match(/const REMOTE_API_BASE = .*?;/);
+  const localLine = source.match(/const LOCAL_API_BASE = .*?;/);
+  const resolverMatch = source.match(
+    /function resolveApiBase\(\) {[\s\S]*?}\n\nconst API_BASE =/,
+  );
+
+  if (!remoteLine || !localLine || !resolverMatch) {
+    throw new Error('Unable to load resolveApiBase from main.js');
+  }
+
+  const resolverSource = resolverMatch[0]
+    .replace(/\n\nconst API_BASE =[\s\S]*/, '\n');
+
+  const factory = new Function(
+    `${remoteLine[0]}\n${localLine[0]}\n${resolverSource}\nreturn { resolveApiBase, LOCAL_API_BASE, REMOTE_API_BASE };`,
+  );
+
+  return factory();
+}
+
+test('resolveApiBase falls back to local when running on localhost', () => {
+  const { resolveApiBase, LOCAL_API_BASE, REMOTE_API_BASE } = loadResolver();
+
+  global.window = {
+    location: { hostname: 'localhost', protocol: 'http:' },
+  };
+
+  const resolved = resolveApiBase();
+
+  assert.equal(resolved, LOCAL_API_BASE);
+  assert.notEqual(resolved, REMOTE_API_BASE);
+
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- allow the front-end bundle to resolve the API base from window overrides, meta tags, or localhost defaults
- document how hosts can provide the API URL via templates, HTML editors, or config files
- add a node smoke test to ensure localhost deployments fall back to the bundled API path

## Testing
- node --test tests/frontend/apiBaseResolution.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4c460b9748324b58d34208da0ddc7