### PR TITLE
Automate backend deployment and document PythonAnywhere configuration

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -2,4 +2,9 @@
 deployment:
   tasks:
     - export DEPLOYPATH=$HOME/public_html/wp-content/uploads/greektax
-    - /bin/cp -r src/frontend/* "$DEPLOYPATH"
+    - /bin/mkdir -p "$DEPLOYPATH"
+    - /bin/rsync -av --delete src/frontend/ "$DEPLOYPATH"/
+    - if ! /bin/grep -q 'data-api-base' "$DEPLOYPATH/index.html"; then
+        /bin/sed -i '0,/<head>/s//<head>\n    <meta data-api-base="https:\/\/cntanos.pythonanywhere.com\/api\/v1">/' "$DEPLOYPATH/index.html";
+      fi
+    - /bin/chmod -R o-rwx "$DEPLOYPATH"/../

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,67 @@
+name: Deploy backend
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/greektax/**"
+      - "requirements.txt"
+      - "requirements-dev.txt"
+      - "pyproject.toml"
+      - "scripts/**"
+
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://${{ secrets.PYTHONANYWHERE_WEBAPP }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Run pytest
+        run: pytest
+      - name: Run ruff
+        run: ruff check src tests
+      - name: Run mypy
+        run: mypy src
+      - name: Validate YAML configs
+        run: python -m greektax.backend.config.validator
+      - name: Push code to PythonAnywhere
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ssh.pythonanywhere.com
+          username: ${{ secrets.PYTHONANYWHERE_USERNAME }}
+          key: ${{ secrets.PYTHONANYWHERE_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /home/${PYTHONANYWHERE_USERNAME}/greektax
+            git fetch --prune
+            git reset --hard origin/main
+            source ${{ secrets.PYTHONANYWHERE_VENV }}/bin/activate
+            pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install .
+      - name: Reload web app
+        env:
+          USERNAME: ${{ secrets.PYTHONANYWHERE_USERNAME }}
+          WEBAPP: ${{ secrets.PYTHONANYWHERE_WEBAPP }}
+          TOKEN: ${{ secrets.PYTHONANYWHERE_API_TOKEN }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Token ${TOKEN}" \
+            https://www.pythonanywhere.com/api/v0/user/${USERNAME}/webapps/${WEBAPP}/reload/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,34 @@ flask --app greektax.backend.app:create_app run
 If the variable is unset or empty, cross-origin requests are rejected for both
 the Flask-Cors integration and the built-in fallback.
 
+### 4a. Configure PythonAnywhere production settings
+
+PythonAnywhere's free tier does not expose an environment-variable UI, so set
+`GREEKTAX_ALLOWED_ORIGINS` inside the WSGI entrypoint instead. Replace
+`/var/www/cntanos_pythonanywhere_com_wsgi.py` with the snippet below (adjust the
+username if you fork the project):
+
+```python
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("GREEKTAX_ALLOWED_ORIGINS", "https://www.cognisys.gr")
+
+project_root = Path("/home/cntanos/greektax")
+sys.path.insert(0, str(project_root / "src"))
+
+from greektax.backend.app import create_app  # noqa: E402
+
+application = create_app()
+```
+
+- `os.environ.setdefault` injects the production allow-list so only your public
+  UI domain can call the API. Update the URL if the front-end moves.
+- The `sys.path` insertion ensures the WSGI loader can import the Flask app.
+- After saving the file, click **Reload** in the PythonAnywhere Web dashboard to
+  apply the changes.
+
 ### 5. Point static deployments at the correct API base URL
 
 The front-end script now detects the API endpoint from the hosting environment


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that reuses the full CI suite before deploying to PythonAnywhere over SSH
- harden the cPanel deployment script by syncing the static bundle and injecting the production API base URL
- document how to set the GREEKTAX_ALLOWED_ORIGINS allow-list directly in the PythonAnywhere WSGI file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4c223711c83248981b2bc3fcfbfd7