### PR TITLE
Add bundled year metadata fallback for legacy backend

### DIFF
--- a/src/frontend/assets/data/config-years.json
+++ b/src/frontend/assets/data/config-years.json
@@ -1,0 +1,2890 @@
+{
+  "default_year": 2026,
+  "years": [
+    {
+      "agricultural": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "employment": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.1387,
+          "employer_rate": 0.2229,
+          "monthly_salary_cap": 7126.94
+        },
+        "defaults": {},
+        "family_tax_credit": {
+          "estimate": false,
+          "pending_confirmation": false,
+          "reduction_factor": null
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "tekmiria": {
+          "enabled": false,
+          "reduction_factor": null
+        },
+        "tekmiria_reduction_factor": null,
+        "youth": {
+          "bands": []
+        }
+      },
+      "freelance": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "defaults": {},
+        "efka_categories": [
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 50.0,
+            "id": "general_class_1",
+            "label_key": "forms.freelance.efka.category.general_class_1",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 252.08,
+            "pension_monthly_amount": 202.08
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 60.0,
+            "id": "general_class_2",
+            "label_key": "forms.freelance.efka.category.general_class_2",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 302.59,
+            "pension_monthly_amount": 242.59
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 70.0,
+            "id": "general_class_3",
+            "label_key": "forms.freelance.efka.category.general_class_3",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 363.47,
+            "pension_monthly_amount": 293.47
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 85.0,
+            "id": "general_class_4",
+            "label_key": "forms.freelance.efka.category.general_class_4",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 437.61,
+            "pension_monthly_amount": 352.61
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 95.0,
+            "id": "general_class_5",
+            "label_key": "forms.freelance.efka.category.general_class_5",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 516.47,
+            "pension_monthly_amount": 421.47
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 109.0,
+            "id": "general_class_6",
+            "label_key": "forms.freelance.efka.category.general_class_6",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 607.96,
+            "pension_monthly_amount": 498.96
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": "forms.freelance.efka.category.general_reduced_description",
+            "estimate": false,
+            "health_monthly_amount": 41.0,
+            "id": "general_reduced",
+            "label_key": "forms.freelance.efka.category.general_reduced",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 151.25,
+            "pension_monthly_amount": 110.25
+          },
+          {
+            "auxiliary_monthly_amount": 42.51,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 72.19,
+            "id": "engineer_class_1",
+            "label_key": "forms.freelance.efka.category.engineer_class_1",
+            "lump_sum_monthly_amount": 27.64,
+            "monthly_amount": 327.29,
+            "pension_monthly_amount": 255.1
+          },
+          {
+            "auxiliary_monthly_amount": 49.61,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 86.55,
+            "id": "engineer_class_2",
+            "label_key": "forms.freelance.efka.category.engineer_class_2",
+            "lump_sum_monthly_amount": 32.38,
+            "monthly_amount": 389.73,
+            "pension_monthly_amount": 303.18
+          },
+          {
+            "auxiliary_monthly_amount": 58.99,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 102.7,
+            "id": "engineer_class_3",
+            "label_key": "forms.freelance.efka.category.engineer_class_3",
+            "lump_sum_monthly_amount": 38.52,
+            "monthly_amount": 464.54,
+            "pension_monthly_amount": 361.84
+          }
+        ],
+        "pending_contribution_update": false,
+        "trade_fee": {
+          "fee_sunset": false,
+          "newly_self_employed_reduction_years": 5,
+          "reduced_amount": 325.0,
+          "standard_amount": 650.0,
+          "sunset": {
+            "description_key": "hints.freelance-trade-fee-sunset",
+            "documentation_key": null,
+            "documentation_url": "https://www.aade.gr/epiheiriseis/telos-epitidevmatos",
+            "status_key": "statuses.trade_fee.scheduled",
+            "year": 2025
+          }
+        },
+        "youth": {
+          "bands": []
+        }
+      },
+      "meta": {
+        "notes": "Initial 2024 configuration with employment and freelance coverage",
+        "status": "draft",
+        "version": 1
+      },
+      "other": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "pension": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.0,
+          "employer_rate": 0.0,
+          "monthly_salary_cap": null
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "youth": {
+          "bands": []
+        }
+      },
+      "rental": {
+        "brackets": [
+          {
+            "rate": 0.15,
+            "type": "single",
+            "upper": 12000.0
+          },
+          {
+            "rate": 0.35,
+            "type": "single",
+            "upper": 35000.0
+          },
+          {
+            "rate": 0.45,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "toggles": {},
+      "warnings": [
+        {
+          "applies_to": [
+            "employment",
+            "pension"
+          ],
+          "documentation_key": "warnings.links.partial_year_review",
+          "documentation_url": "https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias",
+          "id": "employment.partial_year_review",
+          "message_key": "warnings.employment.partial_year_review",
+          "severity": "warning"
+        }
+      ],
+      "year": 2024
+    },
+    {
+      "agricultural": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "employment": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.1337,
+          "employer_rate": 0.2179,
+          "monthly_salary_cap": 7572.62
+        },
+        "defaults": {},
+        "family_tax_credit": {
+          "estimate": false,
+          "pending_confirmation": false,
+          "reduction_factor": null
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "tekmiria": {
+          "enabled": false,
+          "reduction_factor": null
+        },
+        "tekmiria_reduction_factor": null,
+        "youth": {
+          "bands": []
+        }
+      },
+      "freelance": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "defaults": {},
+        "efka_categories": [
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 51.0,
+            "id": "general_class_1",
+            "label_key": "forms.freelance.efka.category.general_class_1",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 260.9,
+            "pension_monthly_amount": 209.9
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 62.0,
+            "id": "general_class_2",
+            "label_key": "forms.freelance.efka.category.general_class_2",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 313.18,
+            "pension_monthly_amount": 251.18
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 72.0,
+            "id": "general_class_3",
+            "label_key": "forms.freelance.efka.category.general_class_3",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 376.19,
+            "pension_monthly_amount": 304.19
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 87.0,
+            "id": "general_class_4",
+            "label_key": "forms.freelance.efka.category.general_class_4",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 452.93,
+            "pension_monthly_amount": 365.93
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 98.0,
+            "id": "general_class_5",
+            "label_key": "forms.freelance.efka.category.general_class_5",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 534.55,
+            "pension_monthly_amount": 436.55
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": false,
+            "health_monthly_amount": 113.0,
+            "id": "general_class_6",
+            "label_key": "forms.freelance.efka.category.general_class_6",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 629.24,
+            "pension_monthly_amount": 516.24
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": "forms.freelance.efka.category.general_reduced_description",
+            "estimate": false,
+            "health_monthly_amount": 42.0,
+            "id": "general_reduced",
+            "label_key": "forms.freelance.efka.category.general_reduced",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 156.54,
+            "pension_monthly_amount": 114.54
+          },
+          {
+            "auxiliary_monthly_amount": 43.99,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 74.72,
+            "id": "engineer_class_1",
+            "label_key": "forms.freelance.efka.category.engineer_class_1",
+            "lump_sum_monthly_amount": 28.61,
+            "monthly_amount": 338.75,
+            "pension_monthly_amount": 264.03
+          },
+          {
+            "auxiliary_monthly_amount": 51.35,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 90.08,
+            "id": "engineer_class_2",
+            "label_key": "forms.freelance.efka.category.engineer_class_2",
+            "lump_sum_monthly_amount": 33.46,
+            "monthly_amount": 403.37,
+            "pension_monthly_amount": 313.29
+          },
+          {
+            "auxiliary_monthly_amount": 60.06,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": false,
+            "health_monthly_amount": 106.1,
+            "id": "engineer_class_3",
+            "label_key": "forms.freelance.efka.category.engineer_class_3",
+            "lump_sum_monthly_amount": 39.87,
+            "monthly_amount": 480.8,
+            "pension_monthly_amount": 374.7
+          }
+        ],
+        "pending_contribution_update": false,
+        "trade_fee": {
+          "fee_sunset": false,
+          "newly_self_employed_reduction_years": null,
+          "reduced_amount": null,
+          "standard_amount": 0.0
+        },
+        "youth": {
+          "bands": []
+        }
+      },
+      "meta": {
+        "notes": "Final 2025 configuration with confirmed family credits and trade fee abolition",
+        "status": "final",
+        "version": 1
+      },
+      "other": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "pension": {
+        "brackets": [
+          {
+            "rate": 0.09,
+            "type": "single",
+            "upper": 10000.0
+          },
+          {
+            "rate": 0.22,
+            "type": "single",
+            "upper": 20000.0
+          },
+          {
+            "rate": 0.28,
+            "type": "single",
+            "upper": 30000.0
+          },
+          {
+            "rate": 0.36,
+            "type": "single",
+            "upper": 40000.0
+          },
+          {
+            "rate": 0.44,
+            "type": "single",
+            "upper": null
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.0,
+          "employer_rate": 0.0,
+          "monthly_salary_cap": null
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "youth": {
+          "bands": []
+        }
+      },
+      "rental": {
+        "brackets": [
+          {
+            "rate": 0.15,
+            "type": "single",
+            "upper": 12000.0
+          },
+          {
+            "rate": 0.35,
+            "type": "single",
+            "upper": 35000.0
+          },
+          {
+            "rate": 0.45,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "toggles": {},
+      "warnings": [
+        {
+          "applies_to": [
+            "employment",
+            "pension"
+          ],
+          "documentation_key": "warnings.links.partial_year_review",
+          "documentation_url": "https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias",
+          "id": "employment.partial_year_review",
+          "message_key": "warnings.employment.partial_year_review",
+          "severity": "warning"
+        }
+      ],
+      "year": 2025
+    },
+    {
+      "agricultural": {
+        "brackets": [
+          {
+            "base_rate": 0.085,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.085
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.08
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.075
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.07
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.065
+                }
+              ],
+              "reduction_factor": 0.02
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 12000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.06
+              },
+              {
+                "band": "under_25",
+                "rate": 0.05
+              }
+            ]
+          },
+          {
+            "base_rate": 0.22,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.22
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.215
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.205
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.195
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.185
+                }
+              ],
+              "reduction_factor": 0.015
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 24000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.195
+              },
+              {
+                "band": "under_25",
+                "rate": 0.18
+              }
+            ]
+          },
+          {
+            "base_rate": 0.29,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.29
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.285
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.275
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.265
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.255
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 36000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.255
+              },
+              {
+                "band": "under_25",
+                "rate": 0.23
+              }
+            ]
+          },
+          {
+            "base_rate": 0.37,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.37
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.365
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.355
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.345
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.335
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 50000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.32
+              },
+              {
+                "band": "under_25",
+                "rate": 0.3
+              }
+            ]
+          },
+          {
+            "base_rate": 0.45,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.45
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.445
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.435
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.425
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.415
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": true,
+            "type": "multi",
+            "upper": null,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.38
+              },
+              {
+                "band": "under_25",
+                "rate": 0.36
+              }
+            ]
+          }
+        ]
+      },
+      "employment": {
+        "brackets": [
+          {
+            "base_rate": 0.09,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.0
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 10000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.2,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.2
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.18
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.16
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.0
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 20000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.26,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.26
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.24
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.22
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.2
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.18
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.16
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.14
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 30000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.26
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.24
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.22
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.2
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.18
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.16
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.14
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.26
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.24
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.22
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.2
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.18
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.16
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.14
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.34,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.34
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 40000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.34
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.34
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.39,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.39
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 60000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.39
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.39
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.44,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.44
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": null,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.44
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.44
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.1337,
+          "employer_rate": 0.2179,
+          "monthly_salary_cap": 7572.62
+        },
+        "defaults": {},
+        "family_tax_credit": {
+          "estimate": true,
+          "pending_confirmation": true,
+          "reduction_factor": 0.95
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "tekmiria": {
+          "enabled": true,
+          "reduction_factor": 0.9
+        },
+        "tekmiria_reduction_factor": 0.9,
+        "youth": {
+          "bands": [
+            "age26_30",
+            "under_25"
+          ]
+        }
+      },
+      "freelance": {
+        "brackets": [
+          {
+            "base_rate": 0.085,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.085
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.08
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.075
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.07
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.065
+                }
+              ],
+              "reduction_factor": 0.02
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 12000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.06
+              },
+              {
+                "band": "under_25",
+                "rate": 0.05
+              }
+            ]
+          },
+          {
+            "base_rate": 0.22,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.22
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.215
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.205
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.195
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.185
+                }
+              ],
+              "reduction_factor": 0.015
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 24000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.195
+              },
+              {
+                "band": "under_25",
+                "rate": 0.18
+              }
+            ]
+          },
+          {
+            "base_rate": 0.29,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.29
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.285
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.275
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.265
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.255
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 36000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.255
+              },
+              {
+                "band": "under_25",
+                "rate": 0.23
+              }
+            ]
+          },
+          {
+            "base_rate": 0.37,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.37
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.365
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.355
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.345
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.335
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 50000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.32
+              },
+              {
+                "band": "under_25",
+                "rate": 0.3
+              }
+            ]
+          },
+          {
+            "base_rate": 0.45,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.45
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.445
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.435
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.425
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.415
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": true,
+            "type": "multi",
+            "upper": null,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.38
+              },
+              {
+                "band": "under_25",
+                "rate": 0.36
+              }
+            ]
+          }
+        ],
+        "defaults": {},
+        "efka_categories": [
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 53.55,
+            "id": "general_class_1",
+            "label_key": "forms.freelance.efka.category.general_class_1",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 273.94,
+            "pension_monthly_amount": 220.4
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 65.1,
+            "id": "general_class_2",
+            "label_key": "forms.freelance.efka.category.general_class_2",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 328.84,
+            "pension_monthly_amount": 263.74
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 75.6,
+            "id": "general_class_3",
+            "label_key": "forms.freelance.efka.category.general_class_3",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 395.0,
+            "pension_monthly_amount": 319.4
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 91.35,
+            "id": "general_class_4",
+            "label_key": "forms.freelance.efka.category.general_class_4",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 475.58,
+            "pension_monthly_amount": 384.23
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 102.9,
+            "id": "general_class_5",
+            "label_key": "forms.freelance.efka.category.general_class_5",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 561.28,
+            "pension_monthly_amount": 458.38
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": null,
+            "estimate": true,
+            "health_monthly_amount": 118.65,
+            "id": "general_class_6",
+            "label_key": "forms.freelance.efka.category.general_class_6",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 660.7,
+            "pension_monthly_amount": 542.05
+          },
+          {
+            "auxiliary_monthly_amount": null,
+            "description_key": "forms.freelance.efka.category.general_reduced_description",
+            "estimate": true,
+            "health_monthly_amount": 44.1,
+            "id": "general_reduced",
+            "label_key": "forms.freelance.efka.category.general_reduced",
+            "lump_sum_monthly_amount": null,
+            "monthly_amount": 164.37,
+            "pension_monthly_amount": 120.27
+          },
+          {
+            "auxiliary_monthly_amount": 46.19,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": true,
+            "health_monthly_amount": 78.46,
+            "id": "engineer_class_1",
+            "label_key": "forms.freelance.efka.category.engineer_class_1",
+            "lump_sum_monthly_amount": 30.04,
+            "monthly_amount": 355.69,
+            "pension_monthly_amount": 277.23
+          },
+          {
+            "auxiliary_monthly_amount": 53.92,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": true,
+            "health_monthly_amount": 94.58,
+            "id": "engineer_class_2",
+            "label_key": "forms.freelance.efka.category.engineer_class_2",
+            "lump_sum_monthly_amount": 35.13,
+            "monthly_amount": 423.54,
+            "pension_monthly_amount": 328.95
+          },
+          {
+            "auxiliary_monthly_amount": 63.06,
+            "description_key": "forms.freelance.efka.category.engineer_description",
+            "estimate": true,
+            "health_monthly_amount": 111.41,
+            "id": "engineer_class_3",
+            "label_key": "forms.freelance.efka.category.engineer_class_3",
+            "lump_sum_monthly_amount": 41.86,
+            "monthly_amount": 504.84,
+            "pension_monthly_amount": 393.44
+          }
+        ],
+        "pending_contribution_update": true,
+        "trade_fee": {
+          "fee_sunset": true,
+          "newly_self_employed_reduction_years": null,
+          "reduced_amount": 0.0,
+          "standard_amount": 0.0
+        },
+        "youth": {
+          "bands": [
+            "age26_30",
+            "under_25"
+          ]
+        }
+      },
+      "meta": {
+        "notes": "2026 configuration with confirmed wage and pension brackets plus provisional credits",
+        "status": "draft",
+        "toggles": {
+          "presumptive_relief": true,
+          "tekmiria_reduction": true
+        },
+        "version": 1
+      },
+      "other": {
+        "brackets": [
+          {
+            "base_rate": 0.085,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.085
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.08
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.075
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.07
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.065
+                }
+              ],
+              "reduction_factor": 0.02
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 12000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.06
+              },
+              {
+                "band": "under_25",
+                "rate": 0.05
+              }
+            ]
+          },
+          {
+            "base_rate": 0.22,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.22
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.215
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.205
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.195
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.185
+                }
+              ],
+              "reduction_factor": 0.015
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 24000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.195
+              },
+              {
+                "band": "under_25",
+                "rate": 0.18
+              }
+            ]
+          },
+          {
+            "base_rate": 0.29,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.29
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.285
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.275
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.265
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.255
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 36000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.255
+              },
+              {
+                "band": "under_25",
+                "rate": 0.23
+              }
+            ]
+          },
+          {
+            "base_rate": 0.37,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.37
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.365
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.355
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.345
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.335
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 50000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.32
+              },
+              {
+                "band": "under_25",
+                "rate": 0.3
+              }
+            ]
+          },
+          {
+            "base_rate": 0.45,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.45
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.445
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.435
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.425
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.415
+                }
+              ],
+              "reduction_factor": 0.01
+            },
+            "pending_confirmation": true,
+            "type": "multi",
+            "upper": null,
+            "youth": [
+              {
+                "band": "age26_30",
+                "rate": 0.38
+              },
+              {
+                "band": "under_25",
+                "rate": 0.36
+              }
+            ]
+          }
+        ]
+      },
+      "pension": {
+        "brackets": [
+          {
+            "base_rate": 0.09,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.0
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 10000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.2,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.2
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.18
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.16
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.09
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.0
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.0
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 20000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.09
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.0
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.0
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.26,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.26
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.24
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.22
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.2
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.18
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.16
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.14
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 30000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.26
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.24
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.22
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.2
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.18
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.16
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.14
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.26
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.24
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.22
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.2
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.18
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.16
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.14
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.34,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.34
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.34
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 40000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.34
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.34
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.34
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.39,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.39
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.39
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": 60000.0,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.39
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.39
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.39
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "base_rate": 0.44,
+            "estimate": false,
+            "household": {
+              "rates": [
+                {
+                  "dependants": 0,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 1,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 2,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 3,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 4,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 5,
+                  "rate": 0.44
+                },
+                {
+                  "dependants": 6,
+                  "rate": 0.44
+                }
+              ],
+              "reduction_factor": null
+            },
+            "pending_confirmation": false,
+            "type": "multi",
+            "upper": null,
+            "youth": [
+              {
+                "band": "age26_30",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.44
+                  }
+                ]
+              },
+              {
+                "band": "under_25",
+                "dependant_rates": [
+                  {
+                    "dependants": 0,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 1,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 2,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 3,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 4,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 5,
+                    "rate": 0.44
+                  },
+                  {
+                    "dependants": 6,
+                    "rate": 0.44
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "contributions": {
+          "employee_rate": 0.0,
+          "employer_rate": 0.0,
+          "monthly_salary_cap": null
+        },
+        "payroll": {
+          "allowed_payments_per_year": [
+            10,
+            12,
+            14
+          ],
+          "default_payments_per_year": 14
+        },
+        "youth": {
+          "bands": [
+            "age26_30",
+            "under_25"
+          ]
+        }
+      },
+      "rental": {
+        "brackets": [
+          {
+            "rate": 0.15,
+            "type": "single",
+            "upper": 12000.0
+          },
+          {
+            "rate": 0.25,
+            "type": "single",
+            "upper": 24000.0
+          },
+          {
+            "rate": 0.35,
+            "type": "single",
+            "upper": 36000.0
+          },
+          {
+            "rate": 0.45,
+            "type": "single",
+            "upper": null
+          }
+        ]
+      },
+      "toggles": {
+        "presumptive_relief": true,
+        "tekmiria_reduction": true
+      },
+      "warnings": [
+        {
+          "applies_to": [
+            "employment",
+            "pension"
+          ],
+          "documentation_key": "warnings.links.partial_year_review",
+          "documentation_url": "https://www.sepenet.gr/el/library/content/apolysi-symvasi-ergasias",
+          "id": "employment.partial_year_review",
+          "message_key": "warnings.employment.partial_year_review",
+          "severity": "warning"
+        }
+      ],
+      "year": 2026
+    }
+  ]
+}

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -60,6 +60,7 @@ function resolveApiBase() {
 const API_BASE = resolveApiBase();
 const CALCULATIONS_ENDPOINT = `${API_BASE}/calculations`;
 const CONFIG_YEARS_ENDPOINT = `${API_BASE}/config/years`;
+const CONFIG_YEARS_FALLBACK_URL = "./assets/data/config-years.json";
 const CONFIG_META_ENDPOINT = `${API_BASE}/config/meta`;
 const CONFIG_INVESTMENT_ENDPOINT = (year, locale) =>
   `${API_BASE}/config/${year}/investment-categories?locale=${encodeURIComponent(
@@ -2469,6 +2470,63 @@ function applyHintToField(hint) {
   }
 }
 
+async function fetchYearConfigurationFallback(cause) {
+  try {
+    const response = await fetch(CONFIG_YEARS_FALLBACK_URL, {
+      credentials: "omit",
+      cache: "no-cache",
+    });
+    if (!response.ok) {
+      const error = new Error(
+        `Unable to load fallback year metadata (${response.status})`,
+      );
+      error.name = "HttpError";
+      error.status = response.status;
+      if (cause) {
+        error.cause = cause;
+      }
+      throw error;
+    }
+
+    const payload = await response.json();
+    if (cause) {
+      console.warn(
+        "Using bundled year metadata because the API endpoint was unavailable.",
+        cause,
+      );
+    } else {
+      console.warn("Using bundled year metadata because API lookup failed.");
+    }
+    return { payload, source: "fallback" };
+  } catch (error) {
+    if (cause && !error.cause) {
+      error.cause = cause;
+    }
+    throw error;
+  }
+}
+
+async function fetchYearConfigurationPayload() {
+  let response;
+  try {
+    response = await fetch(CONFIG_YEARS_ENDPOINT, { credentials: "omit" });
+  } catch (networkError) {
+    console.error("Year metadata request failed", networkError);
+    return fetchYearConfigurationFallback(networkError);
+  }
+
+  if (response.ok) {
+    const payload = await response.json();
+    return { payload, source: "api" };
+  }
+
+  const error = new Error(`Unable to load years (${response.status})`);
+  error.name = "HttpError";
+  error.status = response.status;
+  console.warn("Year metadata endpoint returned an error", error);
+  return fetchYearConfigurationFallback(error);
+}
+
 async function loadYearOptions() {
   if (!yearSelect) {
     return;
@@ -2476,12 +2534,7 @@ async function loadYearOptions() {
 
   setCalculatorStatus(t("status.loading_years"));
   try {
-    const response = await fetch(CONFIG_YEARS_ENDPOINT);
-    if (!response.ok) {
-      throw new Error(`Unable to load years (${response.status})`);
-    }
-
-    const payload = await response.json();
+    const { payload, source } = await fetchYearConfigurationPayload();
     const years = Array.isArray(payload.years) ? payload.years : [];
     yearSelect.innerHTML = "";
     yearMetadataByYear.clear();
@@ -2528,7 +2581,8 @@ async function loadYearOptions() {
       applyYearMetadata(selectedYear);
     }
 
-    setCalculatorStatus(t("status.ready"));
+    const statusTone = source === "fallback" ? "warning" : null;
+    setCalculatorStatus(t("status.ready"), { tone: statusTone });
   } catch (error) {
     console.error("Failed to load year metadata", error);
     setCalculatorStatus(t("status.year_error"), { isError: true });


### PR DESCRIPTION
## Summary
- add a bundled `config-years.json` asset that mirrors the `/api/v1/config/years` response
- update the frontend loader to fall back to the bundled metadata when the API request fails and surface a warning state

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e500e83ec08324ae596c75984432c4