### PR TITLE
Fix mypy issues in localization and API models

### DIFF
--- a/src/greektax/backend/app/localization/catalog.py
+++ b/src/greektax/backend/app/localization/catalog.py
@@ -21,7 +21,10 @@ class Translator:
     _fallback: Mapping[str, str]
 
     def __call__(self, key: str) -> str:
-        return self._messages.get(key) or self._fallback.get(key, key)
+        message = self._messages.get(key)
+        if message is not None:
+            return message
+        return self._fallback.get(key, key)
 
 
 @dataclass(frozen=True)
@@ -43,7 +46,10 @@ def _available_locales() -> tuple[str, ...]:
         return (_BASE_LOCALE,)
 
     locales = sorted(
-        entry.stem for entry in root.iterdir() if entry.suffix == ".json"
+        entry_name[:-5]
+        for entry in root.iterdir()
+        if (entry_name := getattr(entry, "name", None))
+        and entry_name.endswith(".json")
     )
     return tuple(locales) or (_BASE_LOCALE,)
 

--- a/src/greektax/backend/app/models/api.py
+++ b/src/greektax/backend/app/models/api.py
@@ -108,7 +108,7 @@ class EmploymentInput(BaseModel):
 
     @model_validator(mode="after")
     def _synchronise_contribution_flags(self) -> EmploymentInput:
-        fields_set = getattr(self, "model_fields_set", set())
+        fields_set: set[str] = set(getattr(self, "model_fields_set", set()))
         if "include_social_contributions" in fields_set:
             base = bool(self.include_social_contributions)
             if "include_employee_contributions" not in fields_set:
@@ -173,7 +173,7 @@ class FreelanceInput(BaseModel):
     @classmethod
     def _normalise_optional_bool(cls, value: Any, info: ValidationInfo) -> bool:
         if value is None:
-            defaults = {
+            defaults: dict[str, bool] = {
                 "include_trade_fee": True,
                 "include_category_contributions": True,
                 "include_mandatory_contributions": True,
@@ -181,7 +181,8 @@ class FreelanceInput(BaseModel):
                 "include_lump_sum_contributions": True,
                 "newly_self_employed": False,
             }
-            return defaults.get(info.field_name, False)
+            field_name = info.field_name or ""
+            return defaults.get(field_name, False)
         return bool(value)
 
     @field_validator("trade_fee_location", mode="before")


### PR DESCRIPTION
## Summary
- ensure the translator helper returns a definite string fallback
- iterate over translation resources using name attributes compatible with importlib Traversable types
- tighten Employment and Freelance validators with explicit typing to satisfy mypy

## Testing
- mypy src

------
https://chatgpt.com/codex/tasks/task_e_68e5195ad7588324881f9ef615df52de