### PR TITLE
Add workflow check for PythonAnywhere deployment secrets

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -46,6 +46,43 @@ jobs:
         run: mypy src
       - name: Validate YAML configs
         run: python -m greektax.backend.config.validator
+      - name: Validate deployment secrets
+        env:
+          PYTHONANYWHERE_USERNAME: ${{ secrets.PYTHONANYWHERE_USERNAME }}
+          PYTHONANYWHERE_VENV: ${{ secrets.PYTHONANYWHERE_VENV }}
+          PYTHONANYWHERE_API_TOKEN: ${{ secrets.PYTHONANYWHERE_API_TOKEN }}
+          PYTHONANYWHERE_WEBAPP: ${{ secrets.PYTHONANYWHERE_WEBAPP }}
+          PYTHONANYWHERE_SSH_KEY: ${{ secrets.PYTHONANYWHERE_SSH_KEY }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for var in \
+            PYTHONANYWHERE_USERNAME \
+            PYTHONANYWHERE_VENV \
+            PYTHONANYWHERE_API_TOKEN \
+            PYTHONANYWHERE_WEBAPP \
+            PYTHONANYWHERE_SSH_KEY
+          do
+            if [ -z "${!var}" ]; then
+              echo "::error::${var} is empty; update the repository secret before deploying."
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+          temp_key="$(mktemp)"
+          trap 'rm -f "${temp_key}"' EXIT
+          printf '%s\n' "${PYTHONANYWHERE_SSH_KEY}" | tr -d '\r' > "${temp_key}"
+          chmod 600 "${temp_key}"
+
+          if ! ssh-keygen -lf "${temp_key}" >/dev/null 2>&1; then
+            echo "::error::PYTHONANYWHERE_SSH_KEY is not a valid SSH private key."
+            exit 1
+          fi
       - name: Prepare SSH key
         id: prepare-key
         env:


### PR DESCRIPTION
## Summary
- add a validation step that fails the deployment workflow if any PythonAnywhere secret is missing
- verify the uploaded SSH key looks like a valid private key before trying to connect

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e569ab3c6c8324b2dcfcd2d8e3de76