### PR TITLE
Add standalone configuration validation helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use the automated checks to keep the scaffold healthy:
 pytest                         # Execute unit and integration tests
 ruff check src tests           # Lint Python code
 mypy src                       # Static type checks
-python -m greektax.backend.config.validator  # Validate YAML configuration
+python scripts/validate_config.py           # Validate YAML configuration
 ```
 
 ### 3. Refresh localisation bundles when strings change
@@ -204,7 +204,7 @@ Before opening a pull request:
   - Activate recommended editor settings (see `.vscode/` for VS Code defaults).
 - **Update artefacts**
   - Run `pytest`, `ruff check src tests`, and `mypy src`; address failures.
-  - Execute `python -m greektax.backend.config.validator` to catch configuration
+  - Execute `python scripts/validate_config.py` to catch configuration
     regressions.
   - Run `python scripts/embed_translations.py` after localisation updates and
     commit the generated assets.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ Adding a new filing year involves:
 
 1. Copying the most recent YAML file (for example `2026.yaml`) and updating the
    progressive tax brackets, contribution rates, deduction rules, and metadata.
-2. Running `python -m greektax.backend.config.validator` to validate the schema
+2. Running `python scripts/validate_config.py` to validate the schema
    and surface configuration warnings before committing.
 3. Verifying the new year appears through `/api/v1/config/years`; the UI will
    automatically list the year once the file is present.

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Validate YAML configuration files without requiring an editable install."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the src directory is available on the import path when running directly
+# from a Git checkout. This mirrors the convenience provided in ``tests/`` so
+# contributors can execute the validator without first installing the package.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from greektax.backend.config.validator import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repository-local `scripts/validate_config.py` wrapper so configuration validation works without an editable install
- update the README and architecture guide to reference the new helper script

## Testing
- pytest
- python scripts/validate_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e579e1354483249b851bde69823102