### PR TITLE
Fix summary labels translation when switching locales

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -4567,13 +4567,13 @@ function renderDistributionChart(details) {
 }
 
 function resolveSummaryLabel(key, labels = {}, localeOverride = currentLocale) {
-  if (labels && typeof labels[key] === "string" && labels[key].trim()) {
-    return labels[key];
-  }
   const translationKey = `summary.${key}`;
   const translated = t(translationKey, {}, localeOverride);
   if (translated && translated !== translationKey) {
     return translated;
+  }
+  if (labels && typeof labels[key] === "string" && labels[key].trim()) {
+    return labels[key];
   }
   return key;
 }


### PR DESCRIPTION
## Summary
- ensure result summary labels use the bundled locale translations before falling back to API-provided text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8e1c8b79c8324abcfa763abe82125