### PR TITLE
Optimize calculation response construction with optional validation

### DIFF
--- a/src/greektax/backend/app/services/calculation_service.py
+++ b/src/greektax/backend/app/services/calculation_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from numbers import Real
 from time import perf_counter
@@ -69,7 +69,7 @@ def _response_validation_enabled() -> bool:
 
 def _construct_response_model(
     summary: Mapping[str, Any] | Summary,
-    details: list[Mapping[str, Any] | DetailEntry],
+    details: Sequence[Mapping[str, Any] | DetailEntry],
     meta: Mapping[str, Any] | ResponseMeta,
 ) -> CalculationResponse:
     """Construct a ``CalculationResponse`` using fast-path construction by default."""


### PR DESCRIPTION
## Summary
- add a helper that constructs `CalculationResponse` objects via `model_construct` unless a debug flag requests full validation
- use the new helper inside `calculate_tax` so production runs avoid redundant parsing while preserving schema structure
- cover both the fast path and the opt-in validation path with unit tests to ensure the JSON payload is unchanged

## Testing
- pytest tests/unit/test_calculation_service.py::test_calculate_tax_fast_path_skips_response_validation tests/unit/test_calculation_service.py::test_calculate_tax_optional_validation_matches_fast_path

------
https://chatgpt.com/codex/tasks/task_e_68e8ffbf2fa08324b7f5427a56f09ba9