### PR TITLE
Refactor birth year guard income check

### DIFF
--- a/tests/unit/test_calculation_service.py
+++ b/tests/unit/test_calculation_service.py
@@ -211,10 +211,15 @@ def test_validate_birth_year_guard_blocks_income_payloads() -> None:
         _validate_birth_year_guard(
             request.demographics.birth_year,
             request.year,
-            employment,
-            pension,
-            freelance,
-            additional,
+            (
+                employment.income,
+                pension.income,
+                freelance.profit,
+                additional.rental_gross_income,
+                additional.agricultural_gross_revenue,
+                additional.other_taxable_income,
+                *additional.investment_amounts.values(),
+            ),
         )
 
 
@@ -236,10 +241,15 @@ def test_validate_birth_year_guard_allows_no_income() -> None:
     _validate_birth_year_guard(
         request.demographics.birth_year,
         request.year,
-        employment,
-        pension,
-        freelance,
-        additional,
+        (
+            employment.income,
+            pension.income,
+            freelance.profit,
+            additional.rental_gross_income,
+            additional.agricultural_gross_revenue,
+            additional.other_taxable_income,
+            *additional.investment_amounts.values(),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- refactor the birth year guard to work with aggregated income sources, avoiding the ruff PLR0913 violation
- remove the unused pension input assignment flagged by ruff

## Testing
- ruff check src tests

------
https://chatgpt.com/codex/tasks/task_e_68e90c0627e88324a6bf9e4dc6f95fdc