### PR TITLE
Remove presumptive relief metadata surfaces

### DIFF
--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -78,7 +78,7 @@ schema. Unknown top-level or nested keys are rejected (`extra="forbid"`).
 | `other` | object | ❌ | Miscellaneous taxable income inputs. Defaults to zero amounts. |
 | `obligations` | object | ❌ | Flat obligations such as ENFIA and luxury tax. Defaults to zero amounts. |
 | `deductions` | object | ❌ | User-entered deduction amounts. Defaults to zero amounts. |
-| `toggles` | object | ❌ | Optional boolean feature flags (e.g., presumptive relief opt-in). Defaults to `{}` and is merged with configuration toggles from `YearConfiguration.meta`. |
+| `toggles` | object | ❌ | Optional boolean feature flags. Defaults to `{}` and is merged with configuration toggles from `YearConfiguration.meta`. |
 | `withholding_tax` | number | ❌ | Amount of tax already withheld. Defaults to `0`. Must be non-negative. |
 
 ### Dependents
@@ -191,10 +191,7 @@ numeric truthy/falsy representations supported by Pydantic.
   "investment": {"dividends": 800, "interest": 120},
   "obligations": {"enfia": 260},
   "deductions": {"donations": 150, "insurance": 300},
-  "toggles": {
-    "presumptive_relief": true,
-    "tekmiria_reduction": false
-  },
+  "toggles": {"tekmiria_reduction": false},
   "withholding_tax": 1000
 }
 ```
@@ -332,10 +329,7 @@ Key characteristics of the new validation layer:
   "meta": {
     "year": 2024,
     "locale": "en",
-    "youth_relief_category": "under_25",
-    "presumptive_adjustments": [
-      "presumptive_income"
-    ]
+    "youth_relief_category": "under_25"
   }
 }
 ```

--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -5586,18 +5586,6 @@ function buildSummaryExportData(calculation, {
     });
   }
 
-  if (Array.isArray(meta.presumptive_adjustments) && meta.presumptive_adjustments.length) {
-    metaEntries.push({
-      key: "presumptive_adjustments",
-      label:
-        t("export.meta.presumptive_adjustments", {}, locale) ||
-        "Presumptive adjustments",
-      raw: meta.presumptive_adjustments,
-      formatted: formatList(meta.presumptive_adjustments, locale),
-      type: "list",
-    });
-  }
-
   exportData.meta.entries = metaEntries;
 
   return exportData;

--- a/src/frontend/assets/scripts/translations.generated.js
+++ b/src/frontend/assets/scripts/translations.generated.js
@@ -104,7 +104,6 @@
           "currency": "Νόμισμα",
           "generated_at": "Χρόνος δημιουργίας",
           "locale": "Γλώσσα",
-          "presumptive_adjustments": "Τεκμαρτές προσαρμογές",
           "year": "Φορολογικό έτος",
           "youth_relief_category": "Κατηγορία έκπτωσης νέων"
         }
@@ -478,7 +477,6 @@
           "currency": "Currency",
           "generated_at": "Generated",
           "locale": "Locale",
-          "presumptive_adjustments": "Presumptive adjustments",
           "year": "Tax year",
           "youth_relief_category": "Youth relief category"
         }

--- a/src/greektax/backend/app/models/__init__.py
+++ b/src/greektax/backend/app/models/__init__.py
@@ -315,14 +315,6 @@ class CalculationInput(BaseModel):
         return any(amount > 0 for amount in self.investment_amounts.values())
 
     @property
-    def presumptive_adjustments(self) -> tuple[str, ...]:
-        return tuple()
-
-    @property
-    def presumptive_relief_applied(self) -> bool:
-        return False
-
-    @property
     def has_enfia_obligation(self) -> bool:
         return self.enfia_due > 0
 

--- a/src/greektax/backend/app/models/api.py
+++ b/src/greektax/backend/app/models/api.py
@@ -395,7 +395,6 @@ class ResponseMeta(BaseModel):
     year: int
     locale: str
     youth_relief_category: str | None = None
-    presumptive_adjustments: list[str] | None = None
 
 
 class CalculationResponse(BaseModel):

--- a/src/greektax/backend/app/services/calculation_service.py
+++ b/src/greektax/backend/app/services/calculation_service.py
@@ -717,11 +717,6 @@ def calculate_tax(
     if youth_category:
         meta_payload["youth_relief_category"] = youth_category
 
-    if normalised.presumptive_relief_applied:
-        adjustments = list(normalised.presumptive_adjustments)
-        if adjustments:
-            meta_payload["presumptive_adjustments"] = adjustments
-
     response_model = _construct_response_model(summary, details, meta_payload)
 
     return response_model.model_dump(mode="json", exclude_none=True)

--- a/src/greektax/backend/config/data/2026.yaml
+++ b/src/greektax/backend/config/data/2026.yaml
@@ -5,7 +5,6 @@ meta:
   notes: "2026 configuration with confirmed wage and pension brackets plus provisional credits"
   toggles:
     tekmiria_reduction: true
-    presumptive_relief: true
 income:
   employment:
     payroll:

--- a/src/greektax/translations/el.json
+++ b/src/greektax/translations/el.json
@@ -356,8 +356,7 @@
         "year": "Φορολογικό έτος",
         "locale": "Γλώσσα",
         "currency": "Νόμισμα",
-        "youth_relief_category": "Κατηγορία έκπτωσης νέων",
-        "presumptive_adjustments": "Τεκμαρτές προσαρμογές"
+        "youth_relief_category": "Κατηγορία έκπτωσης νέων"
       },
       "deductions": {
         "entered": "Ποσό που καταχωρήθηκε",

--- a/src/greektax/translations/en.json
+++ b/src/greektax/translations/en.json
@@ -356,8 +356,7 @@
         "year": "Tax year",
         "locale": "Locale",
         "currency": "Currency",
-        "youth_relief_category": "Youth relief category",
-        "presumptive_adjustments": "Presumptive adjustments"
+        "youth_relief_category": "Youth relief category"
       },
       "deductions": {
         "entered": "Entered amount",

--- a/tests/data/config_snapshots/config_2026.json
+++ b/tests/data/config_snapshots/config_2026.json
@@ -1239,7 +1239,6 @@
     "notes": "2026 configuration with confirmed wage and pension brackets plus provisional credits",
     "status": "draft",
     "toggles": {
-      "presumptive_relief": true,
       "tekmiria_reduction": true
     },
     "version": 1
@@ -2154,7 +2153,6 @@
     ]
   },
   "toggles": {
-    "presumptive_relief": true,
     "tekmiria_reduction": true
   },
   "warnings": [

--- a/tests/integration/test_config_endpoints.py
+++ b/tests/integration/test_config_endpoints.py
@@ -40,7 +40,7 @@ def test_list_years_endpoint(client: FlaskClient) -> None:
     assert 12 in employment_meta["payroll"]["allowed_payments_per_year"]
     assert employment_meta["contributions"]["employee_rate"] >= 0
     toggles = current_year["meta"].get("toggles", {})
-    assert set(toggles.keys()).issuperset({"presumptive_relief", "tekmiria_reduction"})
+    assert set(toggles.keys()).issuperset({"tekmiria_reduction"})
 
     pension_meta = current_year["pension"]
     assert pension_meta["payroll"]["allowed_payments_per_year"]

--- a/tests/unit/test_calculation_service.py
+++ b/tests/unit/test_calculation_service.py
@@ -325,7 +325,6 @@ def _meta_payload_template() -> dict[str, Any]:
         "year": 2024,
         "locale": "en",
         "youth_relief_category": "standard",
-        "presumptive_adjustments": ["freelance"],
     }
 
 
@@ -2356,32 +2355,6 @@ def test_calculate_tax_multi_year_credit_difference() -> None:
     assert expected_2025["credit"] == pytest.approx(expected_2024["credit"])
     assert expected_2026["credit"] == pytest.approx(expected_2025["credit"])
     assert result_2026["meta"]["year"] == request_2026.year
-
-
-def test_2026_presumptive_relief_defaults_disabled() -> None:
-    """Presumptive adjustments are no longer surfaced for 2026."""
-
-    payload = {"year": 2026, "demographics": {"birth_year": 1985}}
-
-    result = calculate_tax(payload)
-
-    assert "presumptive_adjustments" not in result["meta"]
-
-
-def test_2026_presumptive_relief_ignores_toggle_overrides() -> None:
-    """User-provided toggles or demographics do not trigger presumptive adjustments."""
-
-    payload = {
-        "year": 2026,
-        "demographics": {"birth_year": 1985},
-        "toggles": {"tekmiria_reduction": False, "presumptive_relief": True},
-    }
-
-    result = calculate_tax(payload)
-
-    assert "presumptive_adjustments" not in result["meta"]
-
-
 def test_2026_dependant_credit_tiers_match_taxheaven_schedule() -> None:
     """Dependent credit tiers for 2026 match the Taxheaven-published ladder."""
 


### PR DESCRIPTION
## Summary
- remove presumptive relief metadata plumbing from the API response models and calculation service
- drop the dormant toggle from 2026 configuration data, docs, and associated tests/fixtures
- prune the presumptive translation strings and front-end export handling, regenerating the embedded catalog

## Testing
- python scripts/embed_translations.py
- pytest
- mypy
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e91a05eec88324ac5907d100c08271