### PR TITLE
Document inventory and design notes for cleanup initiative

### DIFF
--- a/docs/cleanup_simplification_plan.md
+++ b/docs/cleanup_simplification_plan.md
@@ -130,6 +130,13 @@ refactors that keep the application deployable throughout the effort.
 1. **Discovery (1 sprint)** – Finalise inventory of configuration files,
    redundant scripts, and unused translations. Produce design docs for the
    configuration schema and front-end modularisation.
+   - Baseline inventory captured in
+     [`Configuration and Tooling Inventory`](reference/configuration_inventory.md),
+     covering tax-year YAML files, bespoke scripts, and translation catalogues
+     alongside noted redundancies and gaps.
+   - Draft design direction documented in
+     [`Configuration Schema Modernisation Notes`](reference/config_schema_design_notes.md)
+     and [`Front-end Modularisation Notes`](reference/frontend_modularisation_notes.md).
 2. **Core refactors (2–3 sprints)** – Ship the new configuration loader,
    simplify the calculation service, and modularise the front-end. Keep changes
    behind feature flags until regression tests pass.

--- a/docs/reference/config_schema_design_notes.md
+++ b/docs/reference/config_schema_design_notes.md
@@ -1,0 +1,32 @@
+# Configuration Schema Modernisation Notes
+
+## Objectives
+
+- Define a single source of truth for tax-year configuration files that can be validated and introspected.
+- Support both legacy flat rate tables (2024–2025) and future multi-dimensional rate matrices (2026+) without bespoke loaders.
+- Provide metadata and feature-flag support so downstream services can conditionally enable behaviour.
+
+## Proposed schema structure
+
+1. **Manifest layer** – Introduce `config/manifest.yaml` listing supported years, file paths, and lifecycle metadata (`status`, `introduced`, `sunset`). Consumers load the manifest first to avoid filesystem scans.
+2. **Year document root** – Normalise root keys to `{meta, toggles, income, deductions, hints, warnings}` with explicit optional sections. Each YAML must declare `meta.schema_version` for migrations.
+3. **Income categories** – Model each income stream as an object with `payroll`, `contributions`, `tax_brackets`, and optional `credits`. Brackets accept either:
+   - `rate` (float) for legacy entries, or
+   - `rates` object describing matrices keyed by demographic dimension plus optional `reduction_factor` descriptors.
+   Validation enforces mutual exclusivity.
+4. **Credits and allowances** – Extract hints/allowances into dedicated sections referencing translation keys by ID. Provide structured arrays for `allowances`, each with `label_key`, `description_key`, `thresholds`.
+5. **Toggles and provisional data** – Reserve `meta.flags` for consumer guidance (`provisional: true`, `requires_confirmation: ["tax_credit"]`). Add `toggles` for runtime feature flags (e.g., `tekmiria_reduction`).
+6. **References** – Allow optional `documentation` blocks with `url` and `label_key` to link to supporting material.
+
+## Validation approach
+
+- Implement Pydantic models mirroring the schema with custom validators handling union types (`rate` vs `rates`).
+- Provide `greektax.backend.config.loader.load_year(year: int)` returning the parsed model plus raw dict for backward compatibility.
+- Update `scripts/validate_config.py` to expose CLI options (`--year`, `--manifest-only`) and surface structured error messages.
+- Add tests covering both schema versions and cross-file consistency (e.g., ensure manifest references actual files).
+
+## Migration considerations
+
+- Write codemods/templates to convert 2024/2025 brackets into explicit objects referencing schema defaults.
+- Introduce compatibility helpers translating legacy field names (e.g., `trade_fee.sunset`) into structured `sunset` objects.
+- Provide documentation describing the schema evolution path and expected release timeline.

--- a/docs/reference/configuration_inventory.md
+++ b/docs/reference/configuration_inventory.md
@@ -1,0 +1,31 @@
+# Configuration and Tooling Inventory (Discovery)
+
+## Tax year YAML files
+
+| File | Status | Notable contents | Redundancies / Gaps |
+| --- | --- | --- | --- |
+| `src/greektax/backend/config/data/2024.yaml` | Draft (meta.status) | Baseline brackets for employment, pension, freelance, agricultural, other, rental, investment; detailed hints and warnings. | Shares identical bracket tables and deduction hints with 2025; no explicit toggles/manifest references. |
+| `src/greektax/backend/config/data/2025.yaml` | Final | Mirrors 2024 structure with updated contribution rates and EFKA amounts; trade fee zeroed out. | Retains full hint set even when fields are unchanged; lacks metadata for post-trade-fee transition; no manifest entry describing supported years. |
+| `src/greektax/backend/config/data/2026.yaml` | Draft | Introduces nested rate matrices by dependants and age groups, provisional credits, and toggle flags. | Structure diverges from 2024/2025 (rates nested vs. flat); missing allowances/hints for deductions except dependents; pending confirmation flags but no consumer guidance. |
+
+**Gaps:** No YAML before 2024 or manifest describing deprecated years; overlapping hints between 2024/2025 create maintenance duplication; 2026 schema not backwards compatible with loaders expecting flat `rate` fields.
+
+## Repository scripts (`scripts/`)
+
+| Script | Purpose | Notes | Redundancies / Gaps |
+| --- | --- | --- | --- |
+| `embed_translations.py` | Embeds `src/greektax/translations/*.json` frontend sections into a generated JS asset. | Writes to `src/frontend/assets/scripts/translations.generated.js`; lacks CLI options or diff detection. | No validation of placeholder usage; duplicates logic from localisation build steps once a module bundler is introduced. |
+| `performance_snapshot.py` | Measures backend calculation timings, asset bundle sizes, and basic accessibility metrics. | Hard-coded sample payload and asset paths; imports backend service via path hack. | Not wired into CI; HTML scanner only counts ARIA usage (no assertions); partly overlaps with `docs/performance_baseline.md`. |
+| `validate_config.py` | Wrapper around `greektax.backend.config.validator.main`. | Bootstraps `src` path for direct execution. | Only proxies to module; lacks CLI for selecting specific years; duplicates entrypoint logic once packaging is standardised. |
+
+**Gaps:** No README or help text for scripts; no task runner integration; no script to diff translation keys or manifest supported years.
+
+## Translation catalogues (`src/greektax/translations/`)
+
+| File | Locales / Sections | Notes | Redundancies / Gaps |
+| --- | --- | --- | --- |
+| `en.json` | `backend` and `frontend` namespaces for English. | Comprehensive backend hints; frontend actions/messages; lacks schema metadata. | Contains keys not referenced in current YAML (e.g., `summary.refund_reduction` duplicates `summary.refund_due`). |
+| `el.json` | Greek translation mirroring `en.json`. | Provides Greek equivalents but backend section includes placeholders for future hints. | Some backend keys present without frontend equivalents; no automation to ensure parity between locales. |
+| `__init__.py` | Declares package exports. | Empty placeholder for namespace package. | No catalogue manifest or helper utilities. |
+
+**Gaps:** Only English and Greek locales provided; no translation manifest for supported languages; no tooling to detect unused keys or keys missing across locales; frontend embed script silently drops backend section.

--- a/docs/reference/frontend_modularisation_notes.md
+++ b/docs/reference/frontend_modularisation_notes.md
@@ -1,0 +1,36 @@
+# Front-end Modularisation Notes
+
+## Goals
+
+- Decompose the monolithic `src/frontend/assets/scripts/main.js` into cohesive modules aligned with calculator features.
+- Establish a lightweight build and bundling pipeline that supports ES module syntax, localisation embedding, and shared state management.
+- Improve testability and accessibility by isolating DOM manipulation and data formatting concerns.
+
+## Proposed module boundaries
+
+1. **`api/client.ts`** – Fetch wrapper handling configuration requests, calculation submissions, and error translation. Exposes typed request/response helpers generated from OpenAPI definitions.
+2. **`state/store.ts`** – Central store (e.g., Zustand or vanilla reactive store) responsible for current form data, derived totals, and persistence to `localStorage` with schema validation.
+3. **`ui/forms/` components** – Small modules per income category that render inputs, subscribe to store slices, and emit events. Each component owns its validation messages and accessibility labels.
+4. **`ui/summary/`** – Formatting utilities and rendering logic for the results summary, including chart adapters.
+5. **`i18n/index.ts`** – Loader consuming generated translation bundles (from the embed script replacement), exposing hooks/utilities for runtime locale switching.
+6. **`bootstrap.ts`** – Entry point wiring modules together, initialising locale, attaching event listeners, and kicking off the first calculation.
+
+## Supporting infrastructure
+
+- Replace the ad-hoc translation embed with a build step that consumes JSON catalogues, validates key parity, and emits typed modules consumed by `i18n/index.ts`.
+- Introduce Vite (or similar) configuration enabling TypeScript, PostCSS, and static asset copying. Output to `dist/` with hashed filenames.
+- Add ESLint/Prettier configuration aligned with the repository’s Python linting philosophy to maintain consistent formatting.
+- Define contract tests using Vitest for store logic and DOM testing library for component behaviour.
+
+## Migration steps
+
+1. **Baseline extraction** – Split `main.js` into `bootstrap.ts` and `api/client.ts` while keeping legacy global functions operational.
+2. **Incremental componentisation** – Port each form section to modules, adding tests before removing legacy code. Maintain exported APIs for existing scripts until parity achieved.
+3. **Enable build pipeline** – Introduce Vite config and adjust CI to run lint/test/build tasks; update deployment scripts to serve bundled assets.
+4. **Retire legacy bundle** – Once modules ship, remove `translations.generated.js` in favour of typed imports, and delete unused global helpers.
+
+## Open questions
+
+- Should the front-end adopt a micro-library (e.g., Preact) for templating, or remain vanilla with template literals?
+- How to expose runtime feature flags (e.g., new schema toggles) to the UI without coupling to build-time constants?
+- What metrics (bundle size, FCP) will define success post-modularisation?


### PR DESCRIPTION
## Summary
- add a discovery inventory covering tax-year configuration files, scripts, and translations
- document proposed configuration schema updates and front-end modularisation approach
- reference the new discovery notes from the cleanup and simplification plan

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e920fd86408324ac361fd5a5789c60