### PR TITLE
Fix frontend module script execution

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1446,6 +1446,6 @@
       </p>
     </footer>
 
-    <script src="./assets/scripts/main.js" defer></script>
+    <script type="module" src="./assets/scripts/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the frontend entry script as an ES module so its imports run in the browser

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e93df49578832487f92688ea7d94db