### PR TITLE
Add bootstrap loader for frontend module

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ without requiring a custom build. Hosting providers can inject
 
   ```html
   <meta data-api-base="https://api.tax.example/api/v1">
-  <script defer src="/assets/scripts/main.js"></script>
+  <script
+    defer
+    src="/assets/scripts/bootstrap.js"
+    data-module="/assets/scripts/main.js"
+  ></script>
   ```
 
 - **Static site generators / template includes**: expose an include or partial
@@ -161,7 +165,11 @@ without requiring a custom build. Hosting providers can inject
       console.warn('Unable to load greektax.config.json; falling back to defaults.', error);
     }
   </script>
-  <script defer src="/assets/scripts/main.js"></script>
+  <script
+    defer
+    src="/assets/scripts/bootstrap.js"
+    data-module="/assets/scripts/main.js"
+  ></script>
   ```
 
   The JSON file can be generated during deployment (e.g. via CI secrets) to

--- a/src/frontend/assets/scripts/bootstrap.js
+++ b/src/frontend/assets/scripts/bootstrap.js
@@ -1,0 +1,67 @@
+/**
+ * Lightweight bootstrapper that ensures the main front-end bundle loads as an
+ * ES module, even if the hosting HTML forgets to mark the script tag with
+ * `type="module"`.
+ */
+
+(function bootstrapFrontendModule() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const loaderScript = document.currentScript;
+  if (!loaderScript) {
+    return;
+  }
+
+  if (loaderScript.dataset.entryModuleLoaded === "true") {
+    return;
+  }
+  loaderScript.dataset.entryModuleLoaded = "true";
+
+  const modulePath =
+    loaderScript.getAttribute("data-module") ?? "./main.js";
+
+  let moduleUrl;
+  try {
+    if (loaderScript.src) {
+      moduleUrl = new URL(modulePath, loaderScript.src).toString();
+    } else {
+      moduleUrl = new URL(modulePath, document.baseURI).toString();
+    }
+  } catch (error) {
+    console.error(
+      "GreekTax could not resolve the front-end module path.",
+      error,
+    );
+    return;
+  }
+
+  const existingModule = document.querySelector(
+    `script[type="module"][data-entry-module="${moduleUrl}"]`,
+  );
+  if (existingModule) {
+    return;
+  }
+
+  const moduleScript = document.createElement("script");
+  moduleScript.type = "module";
+  moduleScript.defer = true;
+  moduleScript.src = moduleUrl;
+  moduleScript.dataset.entryModule = moduleUrl;
+
+  moduleScript.addEventListener("error", (event) => {
+    const detail = event?.error ?? event;
+    console.error(
+      "GreekTax failed to load the front-end module bundle.",
+      detail,
+    );
+  });
+
+  const parent = loaderScript.parentNode ?? document.head;
+  if (loaderScript.nextSibling) {
+    parent.insertBefore(moduleScript, loaderScript.nextSibling);
+  } else {
+    parent.appendChild(moduleScript);
+  }
+})();

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1446,6 +1446,10 @@
       </p>
     </footer>
 
-    <script src="./assets/scripts/main.js" defer></script>
+    <script
+      src="./assets/scripts/bootstrap.js"
+      data-module="./assets/scripts/main.js"
+      defer
+    ></script>
   </body>
 </html>

--- a/tests/integration/test_frontend_shell.py
+++ b/tests/integration/test_frontend_shell.py
@@ -18,7 +18,11 @@ def test_frontend_index_is_served(client: FlaskClient) -> None:
 def test_frontend_assets_are_available(client: FlaskClient) -> None:
     """Static assets must be accessible to hydrate the UI shell."""
 
-    response = client.get("/assets/scripts/main.js")
+    bootstrap_response = client.get("/assets/scripts/bootstrap.js")
+    main_module_response = client.get("/assets/scripts/main.js")
 
-    assert response.status_code == HTTPStatus.OK
-    assert "javascript" in (response.content_type or "").lower()
+    assert bootstrap_response.status_code == HTTPStatus.OK
+    assert "javascript" in (bootstrap_response.content_type or "").lower()
+
+    assert main_module_response.status_code == HTTPStatus.OK
+    assert "javascript" in (main_module_response.content_type or "").lower()


### PR DESCRIPTION
## Summary
- add a bootstrap loader that guarantees the main UI bundle executes as an ES module
- update the HTML shell and documentation to reference the new loader script
- extend the integration test to cover both the bootstrap and module assets

## Testing
- pytest tests/integration/test_frontend_shell.py

------
https://chatgpt.com/codex/tasks/task_e_68e93df49578832487f92688ea7d94db