### PR TITLE
Fix relocation tax residency toggle payload and add regression test

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -3387,9 +3387,11 @@ function buildCalculationPayload() {
   if (birthYear >= 1901 && birthYear <= 2025) {
     demographics.birth_year = birthYear;
   }
-  if (taxResidencyTransferCheckbox?.checked) {
-    demographics.tax_residency_transfer_to_greece = true;
-  }
+
+  const taxResidencyTransferEnabled = Boolean(
+    taxResidencyTransferCheckbox?.checked,
+  );
+  demographics.tax_residency_transfer_to_greece = taxResidencyTransferEnabled;
 
   payload.demographics = demographics;
 


### PR DESCRIPTION
## Summary
- ensure the calculator payload always includes the tax residency transfer flag so the backend can apply the relocation incentive
- add a regression test that verifies the relocation toggle lowers total tax and halves taxable income for employment-only scenarios

## Testing
- pytest tests/unit/test_calculation_service.py -k tax_residency

------
https://chatgpt.com/codex/tasks/task_e_68e96f4fc364832493ccb35861ef7594