### PR TITLE
Skip non-input elements when capturing calculator state

### DIFF
--- a/src/frontend/assets/scripts/main.js
+++ b/src/frontend/assets/scripts/main.js
@@ -993,6 +993,15 @@ function captureCalculatorState() {
   const nameUsage = buildCalculatorFormNameUsage();
 
   elements.forEach((element) => {
+    if (element instanceof HTMLFieldSetElement) {
+      return;
+    }
+    if (element instanceof HTMLButtonElement) {
+      const type = (element.type || "").toLowerCase();
+      if (!type || type === "button" || type === "submit" || type === "reset") {
+        return;
+      }
+    }
     const key = getElementPersistenceKey(element, nameUsage);
     if (!key) {
       warnMissingPersistenceKey(element);
@@ -3387,9 +3396,11 @@ function buildCalculationPayload() {
   if (birthYear >= 1901 && birthYear <= 2025) {
     demographics.birth_year = birthYear;
   }
-  if (taxResidencyTransferCheckbox?.checked) {
-    demographics.tax_residency_transfer_to_greece = true;
-  }
+
+  const taxResidencyTransferEnabled = Boolean(
+    taxResidencyTransferCheckbox?.checked,
+  );
+  demographics.tax_residency_transfer_to_greece = taxResidencyTransferEnabled;
 
   payload.demographics = demographics;
 


### PR DESCRIPTION
## Summary
- skip non-input controls when capturing calculator state so fieldsets and helper buttons no longer trigger persistence warnings

## Testing
- pytest tests/unit/test_calculation_service.py -k tax_residency

------
https://chatgpt.com/codex/tasks/task_e_68e96f4fc364832493ccb35861ef7594