### PR TITLE
Allow calculation requests without explicit demographics payload

### DIFF
--- a/src/greektax/backend/app/models/api.py
+++ b/src/greektax/backend/app/models/api.py
@@ -255,7 +255,7 @@ class CalculationRequest(BaseModel):
     year: int = Field(..., ge=0)
     locale: str = Field(default="en")
     dependents: DependentsInput = Field(default_factory=DependentsInput)
-    demographics: DemographicsInput
+    demographics: DemographicsInput = Field(default_factory=DemographicsInput)
     employment: EmploymentInput = Field(default_factory=EmploymentInput)
     pension: PensionInput = Field(default_factory=PensionInput)
     freelance: FreelanceInput = Field(default_factory=FreelanceInput)

--- a/tests/integration/test_calculation_endpoint.py
+++ b/tests/integration/test_calculation_endpoint.py
@@ -206,3 +206,34 @@ def test_calculation_endpoint_applies_tax_residency_transfer(
         base_summary["taxable_income"] / 2,
     )
     assert relocation_summary["tax_total"] < base_summary["tax_total"]
+
+
+def test_calculation_endpoint_defaults_missing_demographics(
+    client: FlaskClient,
+) -> None:
+    """Omitting demographics from the payload should default to empty values."""
+
+    payload_without_demographics = {
+        "year": 2024,
+        "employment": {"gross_income": 25_000},
+    }
+    explicit_default_payload = {
+        "year": 2024,
+        "employment": {"gross_income": 25_000},
+        "demographics": {},
+    }
+
+    missing_response = client.post(
+        "/api/v1/calculations", json=payload_without_demographics
+    )
+    explicit_response = client.post(
+        "/api/v1/calculations", json=explicit_default_payload
+    )
+
+    assert missing_response.status_code == HTTPStatus.OK
+    assert explicit_response.status_code == HTTPStatus.OK
+
+    missing_summary = missing_response.get_json()["summary"]
+    explicit_summary = explicit_response.get_json()["summary"]
+
+    assert missing_summary == explicit_summary


### PR DESCRIPTION
## Summary
- allow `CalculationRequest` demographics to default to empty values so requests without the field are accepted
- add an integration test ensuring the API returns the same results when demographics is omitted

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e9914206608324acddce57f1401ed6