### PR TITLE
Restore four functions and one export lost in PR #221 refactor

### DIFF
--- a/src/frontend/assets/scripts/charts/distribution.js
+++ b/src/frontend/assets/scripts/charts/distribution.js
@@ -11,7 +11,7 @@ function sumDetailFields(detail, fields, toFiniteNumber) {
   }, 0);
 }
 
-function computeDistributionForDetail(detail, toFiniteNumber) {
+export function computeDistributionForDetail(detail, toFiniteNumber) {
   const empty = { net_income: 0, taxes: 0, insurance: 0, expenses: 0, gross: 0 };
   if (!detail) {
     return empty;

--- a/src/frontend/assets/scripts/ui/app.js
+++ b/src/frontend/assets/scripts/ui/app.js
@@ -17,7 +17,10 @@ import {
   SVG_NS,
   THEME_STORAGE_KEY,
 } from "../config/constants.js";
-import { computeDistributionTotals } from "../charts/distribution.js";
+import {
+  computeDistributionTotals,
+  computeDistributionForDetail,
+} from "../charts/distribution.js";
 import { mergeTranslationCatalogues, isPlainObject } from "../i18n/catalog.js";
 import { createI18nState } from "../state/i18nState.js";
 import { toFiniteNumber } from "../validation/numbers.js";
@@ -3678,7 +3681,7 @@ function renderSankey(result) {
     }
 
     const sourceIndex = ensureNode(sourceLabel);
-    const breakdown = computeDistributionForDetail(detail);
+    const breakdown = computeDistributionForDetail(detail, toFiniteNumber);
     if (!breakdown || breakdown.gross <= 0) {
       return;
     }
@@ -5540,6 +5543,148 @@ function initialiseCalculator() {
       updateEmploymentContributionPreview(lastCalculation?.details || []);
       applyEmploymentModeLabels();
     });
+}
+
+function resolveEmploymentContributionPreviewMessage(type, replacements = {}) {
+  const config = EMPLOYMENT_CONTRIBUTION_PREVIEW_MESSAGES[type];
+  if (!config) {
+    return "";
+  }
+
+  const message = t(config.key, replacements);
+  if (typeof message === "string" && message && message !== config.key) {
+    return message;
+  }
+
+  const locale = getActiveLocale();
+  const fallbackTemplate =
+    (config.fallback && (config.fallback[locale] || config.fallback.en)) || "";
+  if (!fallbackTemplate) {
+    return "";
+  }
+
+  return formatTemplate(fallbackTemplate, replacements);
+}
+
+function getManualEmploymentContributionValue() {
+  if (!employmentEmployeeContributionsInput) {
+    return 0;
+  }
+
+  const raw = (employmentEmployeeContributionsInput.value ?? "").trim();
+  if (!raw) {
+    return 0;
+  }
+
+  const normalised = raw.replace(",", ".");
+  const value = Number.parseFloat(normalised);
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function applyEmploymentContributionPreview(message) {
+  if (!employmentEmployeeContributionsPreview) {
+    return;
+  }
+
+  if (typeof message === "string" && message.trim()) {
+    employmentEmployeeContributionsPreview.textContent = message;
+    employmentEmployeeContributionsPreview.hidden = false;
+  } else {
+    employmentEmployeeContributionsPreview.textContent = "";
+    employmentEmployeeContributionsPreview.hidden = true;
+  }
+}
+
+function applyEmploymentModeLabels() {
+  if (!employmentModeSelect) {
+    return;
+  }
+
+  const annualOption = employmentModeSelect.querySelector(
+    'option[value="annual"]',
+  );
+  const monthlyOption = employmentModeSelect.querySelector(
+    'option[value="monthly"]',
+  );
+
+  if (annualOption) {
+    const annualLabel = t("fields.employment-mode-annual");
+    if (annualLabel && annualLabel !== "fields.employment-mode-annual") {
+      annualOption.textContent = annualLabel;
+    }
+  }
+  if (monthlyOption) {
+    const monthlyLabel = t("fields.employment-mode-monthly");
+    if (monthlyLabel && monthlyLabel !== "fields.employment-mode-monthly") {
+      monthlyOption.textContent = monthlyLabel;
+    }
+  }
+}
+
+function updateEmploymentContributionPreview(details) {
+  if (!employmentEmployeeContributionsPreview) {
+    return;
+  }
+
+  const includeSocial = employmentIncludeSocialToggle
+    ? Boolean(employmentIncludeSocialToggle.checked)
+    : true;
+
+  if (!includeSocial) {
+    const excludedMessage = resolveEmploymentContributionPreviewMessage(
+      "excluded",
+    );
+    applyEmploymentContributionPreview(excludedMessage);
+    return;
+  }
+
+  const manualValue = getManualEmploymentContributionValue();
+  if (manualValue > 0) {
+    const manualMessage = resolveEmploymentContributionPreviewMessage(
+      "manual",
+      {
+        amount: formatCurrency(manualValue),
+      },
+    );
+    applyEmploymentContributionPreview(manualMessage);
+    return;
+  }
+
+  const detailsList = Array.isArray(details) ? details : [];
+  const employmentDetail = detailsList.find(
+    (detail) => detail && detail.category === "employment",
+  );
+
+  if (employmentDetail) {
+    const totalContributions = toFiniteNumber(
+      employmentDetail.employee_contributions,
+    );
+    const manualPortion = toFiniteNumber(
+      employmentDetail.employee_contributions_manual,
+    );
+    const automaticContributions = Math.max(
+      totalContributions - manualPortion,
+      0,
+    );
+
+    if (automaticContributions > 0) {
+      const message = resolveEmploymentContributionPreviewMessage(
+        "automatic",
+        {
+          amount: formatCurrency(automaticContributions),
+        },
+      );
+      applyEmploymentContributionPreview(message);
+      return;
+    }
+  }
+
+  const fallbackMessage = resolveEmploymentContributionPreviewMessage("empty");
+  applyEmploymentContributionPreview(fallbackMessage);
 }
 
 export async function bootstrapApp() {

--- a/tests/frontend/fileSizeGuardrails.test.js
+++ b/tests/frontend/fileSizeGuardrails.test.js
@@ -12,7 +12,7 @@ const guardrails = [
   { path: '../../src/frontend/assets/scripts/api/endpoints.js', maxLines: 120 },
   { path: '../../src/frontend/assets/scripts/charts/distribution.js', maxLines: 220 },
   { path: '../../src/frontend/assets/scripts/i18n/catalog.js', maxLines: 60 },
-  { path: '../../src/frontend/assets/scripts/ui/app.js', maxLines: 5600 },
+  { path: '../../src/frontend/assets/scripts/ui/app.js', maxLines: 5800 },
 ];
 
 test('frontend script files stay within size guardrails', () => {


### PR DESCRIPTION
## Summary

Follow-up to **PR #228** (the two-line `hasAppliedThemeOnce` / `themeTransitionHandle` declarations fix, already merged). After that PR shipped, a JSDOM smoke test of `bootstrapApp()` revealed that **PR #221**'s refactor (commit `353cdfc`, "Refactor frontend script into modular entrypoint and helpers") had dropped *more* than just those two declarations — four function definitions were lost, and a fifth function was moved into `charts/distribution.js` without being exported.

Until those four functions are restored and the missing export is added, `bootstrapApp()` runs `applyTheme` cleanly (thanks to #228) but then aborts in `applyLocale` on the next `ReferenceError`, leaving the page just as inert as before — no event handlers, no API calls, inert "Calculate" button.

## What this PR does

### Restore four functions in `src/frontend/assets/scripts/ui/app.js`

Sourced verbatim from `353cdfc^:src/frontend/assets/scripts/main.js`:

| Symbol | Pre-refactor location | Call sites in app.js |
|---|---|---|
| `applyEmploymentModeLabels` | line 3990 | reached on every page load via `applyLocale` |
| `updateEmploymentContributionPreview` | line 4016 | reached on every page load via `applyLocale`, plus form/input handlers |
| `resolveEmploymentContributionPreviewMessage` | line 3936 | helper consumed by the two above |
| `getManualEmploymentContributionValue` | line 3957 | helper consumed by the two above |
| `applyEmploymentContributionPreview` | line 3976 | helper consumed by the two above |

### Export `computeDistributionForDetail` from `charts/distribution.js`

The refactor moved this function into `charts/distribution.js` but kept it private. The call in `app.js` (reached after every calculation) therefore also threw `ReferenceError`. Add `export`, import the symbol in `app.js`, and update the call site to pass `toFiniteNumber` (the function's second parameter).

### Bump line-budget guardrail

`tests/frontend/fileSizeGuardrails.test.js`: raise the `ui/app.js` ceiling from 5600 → 5800 lines. The 5600 ceiling was set against the post-refactor file *with the missing functions removed*, so it was artificially low.

## Verification

- [x] AST sweep: no undeclared bare-identifier calls in `app.js`
- [x] JSDOM smoke test: `bootstrapApp()` returns; module logs `GreekTax interface initialised`
- [x] `node --test tests/frontend/*.test.js` — all 8 tests pass
- [x] `ruff check src tests` clean
- [x] `mypy src` clean
- [x] `python scripts/check_bundle_size.py` budgets satisfied
- [x] `python scripts/validate_config.py` clean
- [ ] `https://www.cognisys.gr/greektax/` loads with no `ReferenceError` in the browser console
- [ ] "Calculate" button issues a request to the configured API base and renders a result
- [ ] Theme toggle switches `data-theme` and the `theme-transition` class clears after ~280 ms

## Pre-existing failures (unrelated, do not block this PR)

Four pytest failures predate this branch and do not touch frontend JS:

- `tests/e2e/test_smoke_flow.py::test_smoke_user_flow`
- `tests/integration/test_request_limits.py::test_calculation_endpoint_rejects_oversized_payload`
- `tests/integration/test_security_headers.py::test_api_responses_include_security_headers`
- `tests/integration/test_security_headers.py::test_secure_requests_include_hsts_header`

The `node --test tests/frontend` step in `scripts/quality.py` also fails on Node 24 (Windows) due to a path-vs-glob invocation issue — `node --test tests/frontend/*.test.js` passes cleanly.

## Follow-ups (NOT in this PR)

1. **Production API base.** `endpoints.js` defaults to same-origin `/api/v1`. If `www.cognisys.gr` does not reverse-proxy `/api/*` to the PythonAnywhere Flask app, the calculator will still fail to reach the backend even after this PR lands. Resolve via reverse proxy, or add `<meta data-api-base="https://<account>.pythonanywhere.com/api/v1">` to `src/frontend/index.html` and configure CORS for the `cognisys.gr` origin.
2. **Documentation drift.** `docs/documentation_audit.md` line 12 references a README section "Configuring the API endpoint" that no longer exists in `README.md`. Worth restoring in a separate small docs PR.
3. **JSDOM bootstrap smoke test.** Nothing in `tests/` exercises `bootstrapApp`, which is exactly why this multi-symbol regression slipped through PR #221 and was not caught by the initial fix in PR #228 either. A JSDOM smoke test that imports `bootstrapApp` and asserts it completes without throwing would close the gap. I have a working draft (`scripts/_smoke_bootstrap_jsdom.mjs`, currently untracked); happy to promote it to `tests/frontend/bootstrapSmoke.test.js` in a follow-up.
