### PR TITLE
Point frontend at PythonAnywhere API host via meta tag

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
+    <meta data-api-base="https://cntanos.pythonanywhere.com/api/v1" />
     <title>CogniSys-GreekTax</title>
     <link rel="stylesheet" href="./assets/styles/main.css" />
   </head>


### PR DESCRIPTION
## Summary

The cPanel-deployed `cognisys.gr/greektax/` build was hitting `/api/v1/*` on its own origin (WordPress), so `config/years` and `config/meta` returned **404** and bootstrap could not populate year metadata. After PR #229 the JS bundle runs end-to-end, which made this surface as the next user-visible blocker.

Both `REMOTE_API_BASE` and `LOCAL_API_BASE` in `src/frontend/assets/scripts/api/endpoints.js` default to the relative `/api/v1`. `resolveApiBase()` already supports a `<meta data-api-base="…">` override (lines 22–32). This PR uses that mechanism: one HTML line in `src/frontend/index.html`, no JS change.

```html
<meta data-api-base="https://cntanos.pythonanywhere.com/api/v1" />
```

## Why a meta tag instead of editing `endpoints.js`

- **Reversible per deployment.** A fork that targets a different backend can edit one line of HTML without forking the JS.
- **Already supported.** `resolveApiBase()` was built for this; no new code path.
- **Decouples deploy config from source.** Future hosting-target changes (e.g. moving off PythonAnywhere) become an HTML edit, not a code change.

## Verification

- [x] `node --test tests/frontend/apiBaseResolution.test.js` — 4/4 pass
- [x] JSDOM smoke loads the real `index.html`, calls `resolveApiBase()` against `window.location = https://www.cognisys.gr/greektax/`, asserts it returns `https://cntanos.pythonanywhere.com/api/v1` — pass
- [x] CORS from `cognisys.gr` to `cntanos.pythonanywhere.com/api/v1/*` already permits the calls (verified by manual cross-origin fetch during diagnosis returning 200 + parseable JSON)
- [ ] After deploy: `https://www.cognisys.gr/greektax/` issues `GET https://cntanos.pythonanywhere.com/api/v1/config/years` (not `cognisys.gr/api/v1/...`) and the form populates with year metadata
- [ ] "Calculate" produces a result without console errors

## Follow-ups (NOT in this PR)

1. **Cache busting on the cPanel build.** Static assets are served with `Cache-Control: public, max-age=31536000, immutable` but `<script src="./assets/scripts/main.js">` has no version hash or query string. This produced visible confusion during the last debug cycle (stale module bundles, ghost SyntaxErrors that vanished only on hard reload). Adding a `?v=<release>` suffix on each deploy — or moving to content-hashed filenames — would save real time on the next bug fix.

2. **No CORS allowlist in this repo.** The CORS allowlist that lets `cognisys.gr` reach the PythonAnywhere backend lives on the server side. Worth documenting in `docs/operations.md` so it doesn't get forgotten on a future redeploy.

3. **Documentation drift (still open).** `docs/documentation_audit.md` line 12 references a README section "Configuring the API endpoint" that no longer exists. With this PR, the meta-tag override mechanism is now active — restoring that README section to document `data-api-base` and `window.GREEKTAX_API_BASE` would be timely.
