### PR TITLE
Inject API base at deploy time instead of hardcoding the backend host

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,6 +49,19 @@ frontend static checks, and bundle-size budgets.
 5. For outdated dependencies:
    - prioritize security and runtime-critical packages first, then batch lower-risk updates in scheduled maintenance PRs.
 
+## Frontend API base injection
+
+The source `src/frontend/index.html` stays deployment-agnostic: it ships with no `<meta data-api-base>` tag and `resolveApiBase()` falls back to the same-origin `/api/v1`. Cross-origin deployments (where the static frontend and the Flask backend live on different hosts) inject the meta tag at deploy time with `scripts/configure_frontend.py`:
+
+```bash
+GREEKTAX_API_BASE=https://<account>.pythonanywhere.com/api/v1 \
+    python scripts/configure_frontend.py --target /path/to/served/index.html
+```
+
+The injection sits inside `<!-- @greektax/api-base:start --> ... <!-- @greektax/api-base:end -->` markers, so the script is idempotent — re-running it replaces any previous block. Running it with `GREEKTAX_API_BASE` unset or empty removes any prior injection, returning the file to its same-origin default. Keep the backend host value out of the repo: source it from a deploy-time environment variable, a non-committed config file, or a CI secret.
+
+For cPanel-based deploys, invoke the script from `.cpanel.yml` (or the equivalent post-deploy hook) after the static files have been copied into the docroot. CORS must permit the frontend origin → backend origin call; verify with a manual cross-origin fetch before relying on the deployed page.
+
 ## Year configuration refreshes
 
 When introducing or updating filing years in `src/greektax/backend/config/data/*.yaml`:

--- a/scripts/configure_frontend.py
+++ b/scripts/configure_frontend.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Inject deployment-specific configuration into the served frontend.
+
+Reads ``GREEKTAX_API_BASE`` from the environment and injects a
+``<meta data-api-base="..." />`` tag into a deployed ``index.html`` so the
+frontend points its API calls at the right backend host. The source
+``src/frontend/index.html`` stays deployment-agnostic.
+
+Intended to run from a deploy hook (cPanel ``.cpanel.yml``, GitHub
+Actions, etc.) after the static files have been placed in the docroot.
+Re-running is safe: any previous injection is replaced. When the env
+var is unset or empty, any previous injection is removed so the
+frontend falls back to its same-origin default.
+
+Usage::
+
+    GREEKTAX_API_BASE=https://example.com/api/v1 \\
+        python scripts/configure_frontend.py --target /path/to/index.html
+
+Exit codes:
+    0 on success (including the env-unset cleanup path)
+    1 on usage/IO errors
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+MARKER_OPEN = "<!-- @greektax/api-base:start -->"
+MARKER_CLOSE = "<!-- @greektax/api-base:end -->"
+INJECTION_PATTERN = re.compile(
+    re.escape(MARKER_OPEN) + r".*?" + re.escape(MARKER_CLOSE) + r"\s*",
+    re.DOTALL,
+)
+HEAD_CLOSE = "</head>"
+
+
+def _strip_previous(html: str) -> str:
+    return INJECTION_PATTERN.sub("", html)
+
+
+def _build_block(api_base: str) -> str:
+    return (
+        f"    {MARKER_OPEN}\n"
+        f'    <meta data-api-base="{api_base}" />\n'
+        f"    {MARKER_CLOSE}\n  "
+    )
+
+
+def configure(target: Path, api_base: str) -> str:
+    """Inject (or remove) the meta tag in ``target``.
+
+    Returns a short status string for logging. Raises ``RuntimeError``
+    if the target lacks a ``</head>`` tag and an injection is needed.
+    """
+    html = target.read_text(encoding="utf-8")
+    stripped = _strip_previous(html)
+
+    if not api_base:
+        if stripped != html:
+            target.write_text(stripped, encoding="utf-8")
+            return "removed previous data-api-base injection"
+        return "no data-api-base configured; left target unchanged"
+
+    head_idx = stripped.find(HEAD_CLOSE)
+    if head_idx == -1:
+        raise RuntimeError(f"could not find {HEAD_CLOSE!r} in {target}")
+    new_html = stripped[:head_idx] + _build_block(api_base) + stripped[head_idx:]
+    target.write_text(new_html, encoding="utf-8")
+    return f"injected data-api-base={api_base}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inject GREEKTAX_API_BASE into a deployed index.html.",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=Path("src/frontend/index.html"),
+        help="path to the index.html that will be served (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    api_base = (os.environ.get("GREEKTAX_API_BASE") or "").strip()
+
+    if not args.target.exists():
+        print(f"error: {args.target} does not exist", file=sys.stderr)
+        return 1
+    try:
+        status = configure(args.target, api_base)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(status)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_configure_frontend.py
+++ b/tests/unit/test_configure_frontend.py
@@ -1,0 +1,122 @@
+"""Unit tests for scripts/configure_frontend.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "configure_frontend.py"
+    spec = importlib.util.spec_from_file_location("configure_frontend", script_path)
+    assert spec and spec.loader, "could not locate configure_frontend.py"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+configure_frontend = _load_module()
+
+
+HTML = (
+    "<!DOCTYPE html>\n"
+    "<html><head>\n"
+    "<meta charset=\"utf-8\" />\n"
+    "<title>GreekTax</title>\n"
+    "</head><body>hello</body></html>\n"
+)
+
+
+def test_inject_adds_meta_tag(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+
+    status = configure_frontend.configure(target, "https://api.example.com/v1")
+
+    assert "injected" in status
+    output = target.read_text(encoding="utf-8")
+    assert '<meta data-api-base="https://api.example.com/v1" />' in output
+    assert configure_frontend.MARKER_OPEN in output
+    assert configure_frontend.MARKER_CLOSE in output
+    assert output.index(configure_frontend.MARKER_OPEN) < output.index("</head>")
+
+
+def test_inject_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+
+    configure_frontend.configure(target, "https://first.example/v1")
+    configure_frontend.configure(target, "https://second.example/v1")
+
+    output = target.read_text(encoding="utf-8")
+    assert output.count(configure_frontend.MARKER_OPEN) == 1
+    assert '<meta data-api-base="https://second.example/v1" />' in output
+    assert "first.example" not in output
+
+
+def test_empty_api_base_removes_previous_injection(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+
+    configure_frontend.configure(target, "https://api.example.com/v1")
+    status = configure_frontend.configure(target, "")
+
+    assert "removed" in status
+    output = target.read_text(encoding="utf-8")
+    assert configure_frontend.MARKER_OPEN not in output
+    assert "data-api-base" not in output
+
+
+def test_empty_api_base_on_clean_file_is_a_noop(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+
+    status = configure_frontend.configure(target, "")
+
+    assert "unchanged" in status
+    assert target.read_text(encoding="utf-8") == HTML
+
+
+def test_missing_head_close_tag_errors(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text("<html><body>no head close</body></html>", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="could not find"):
+        configure_frontend.configure(target, "https://api.example.com/v1")
+
+
+def test_main_exits_nonzero_when_target_missing(tmp_path: Path) -> None:
+    rc = configure_frontend.main(["--target", str(tmp_path / "absent.html")])
+    assert rc == 1
+
+
+def test_main_succeeds_with_env_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+    monkeypatch.setenv("GREEKTAX_API_BASE", "https://env.example/v1")
+
+    rc = configure_frontend.main(["--target", str(target)])
+
+    assert rc == 0
+    output = target.read_text(encoding="utf-8")
+    assert '<meta data-api-base="https://env.example/v1" />' in output
+
+
+def test_main_with_unset_env_var_is_clean_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(HTML, encoding="utf-8")
+    monkeypatch.delenv("GREEKTAX_API_BASE", raising=False)
+
+    rc = configure_frontend.main(["--target", str(target)])
+
+    assert rc == 0
+    assert target.read_text(encoding="utf-8") == HTML


### PR DESCRIPTION
## Summary

Supersedes the closed **PR #230**, which embedded the PythonAnywhere host directly in `src/frontend/index.html`. That approach (a) committed a value the project treats as a secret — `PYTHONANYWHERE_USERNAME` is in `secrets:`, not `vars:`, in `.github/workflows/deploy-backend.yml`, which is why deploy logs show it masked as `***` — and (b) coupled the canonical source to one specific deployment, undoing PR #219's "Use same-origin API default and document explicit overrides" decision.

This PR moves the override out of source and into the deploy step.

## What changed

1. **`scripts/configure_frontend.py`** — small stdlib-only injector that reads `GREEKTAX_API_BASE` from the environment and writes a `<meta data-api-base="…">` tag into a target `index.html`, between idempotent markers:

   ```html
   <!-- @greektax/api-base:start -->
       <meta data-api-base="https://example.com/api/v1" />
       <!-- @greektax/api-base:end -->
   ```

   Re-running replaces any previous block (idempotent). Running with the env var unset removes any prior injection, so dev/test environments fall back to the same-origin default.

2. **`tests/unit/test_configure_frontend.py`** — 8 unit tests covering injection, idempotency, removal, the env-unset clean path, the missing-`</head>` error path, and the CLI entry point.

3. **`docs/operations.md`** — new section documenting the deploy-time invocation, the idempotency contract, and the cPanel `.cpanel.yml` integration point.

`src/frontend/index.html` itself is unchanged — the source stays deployment-agnostic.

## Verification

- [x] `pytest tests/unit/test_configure_frontend.py` — 8/8 pass
- [x] `ruff check`, `mypy src` clean
- [x] `node --test tests/frontend/*.test.js` — 8/8 pass (existing tests unaffected)
- [x] End-to-end smoke (`scripts/_smoke_configure_frontend_e2e.mjs`, untracked): runs the injector against a temp copy of the real `index.html`, loads the output into JSDOM, and asserts `resolveApiBase()` returns the injected URL → pass
- [ ] After deploy, cPanel post-deploy hook sets `GREEKTAX_API_BASE=https://cntanos.pythonanywhere.com/api/v1` and invokes the script against the docroot `index.html`. Live site issues `GET https://cntanos.pythonanywhere.com/api/v1/config/years` instead of `cognisys.gr/api/v1/...`, and the form populates.

## Why a placeholder-substitution script and not, say, a runtime feature

`resolveApiBase()` already exposes a `<meta data-api-base>` override (lines 22-32 of `src/frontend/assets/scripts/api/endpoints.js`). The remaining question was only *who* writes the tag and *when*. Doing it at deploy time:

- Keeps the host out of git history.
- Stays compatible with any host (cPanel, static hosting, S3, GitHub Pages, etc.) — the script just rewrites a file.
- Requires no new JS, no new runtime code path, no build tool.
- Makes the dev / prod separation explicit: source = deployment-agnostic, deploy script = the only place the host is named.

## How to hook this into cPanel

Add to `.cpanel.yml` (or your equivalent post-deploy hook), after the static files have been copied into the docroot:

```yaml
- export DEPLOYPATH=/home/$USER/public_html/greektax
- /bin/cp -R src/frontend/* $DEPLOYPATH
- python3 scripts/configure_frontend.py --target $DEPLOYPATH/index.html
```

…with `GREEKTAX_API_BASE` set as a cPanel environment variable, or sourced from a non-committed `~/.greektax-deploy.env` file (`set -a; source ~/.greektax-deploy.env; set +a`).

## Follow-ups (NOT in this PR)

1. **Cache busting on cPanel.** Static assets are served with `Cache-Control: public, max-age=31536000, immutable` but `<script src="./assets/scripts/main.js">` has no version query. Today's debug cycle wasted real time on stale module bundles and ghost `SyntaxError`s. A `?v=<commit-sha>` suffix or content-hashed filenames would prevent that on the next bug fix.
2. **Restore the "Configuring the API endpoint" README section** that `docs/documentation_audit.md:12` references. With the meta-tag pathway documented in `docs/operations.md`, the corresponding user-facing README section is the missing piece.
3. **CORS allowlist documentation.** The cognisys.gr → PythonAnywhere CORS rule that makes this work lives on the backend; document it in `docs/operations.md` so a future redeploy doesn't drop it.
