### PR TITLE
Wire configure_frontend.py into the cPanel deploy

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -3,3 +3,5 @@ deployment:
   tasks:
     - export DEPLOYPATH=$HOME/public_html/wp-content/uploads/greektax
     - /bin/cp -r src/frontend/* "$DEPLOYPATH"
+    - if [ -f "$HOME/.greektax-deploy.env" ]; then set -a; . "$HOME/.greektax-deploy.env"; set +a; fi
+    - python3 scripts/configure_frontend.py --target "$DEPLOYPATH/index.html"


### PR DESCRIPTION
## Summary

PR #231 added `scripts/configure_frontend.py` and documented how to call it from a deploy hook, but **did not edit `.cpanel.yml`** to actually invoke it. So after #231 merged and shipped, the deploy continued to copy `src/frontend/*` to the docroot without ever injecting the `<meta data-api-base>` tag. The live site fell back to same-origin `/api/v1`, which is WordPress on `cognisys.gr`, which returned 404 for `config/years` and `config/meta` — exactly the symptom we'd already diagnosed.

This PR fixes that omission by adding two lines to `.cpanel.yml`.

## What changed

```yaml
deployment:
  tasks:
    - export DEPLOYPATH=$HOME/public_html/wp-content/uploads/greektax
    - /bin/cp -r src/frontend/* "$DEPLOYPATH"
+   - if [ -f "$HOME/.greektax-deploy.env" ]; then set -a; . "$HOME/.greektax-deploy.env"; set +a; fi
+   - python3 scripts/configure_frontend.py --target "$DEPLOYPATH/index.html"
```

- `~/.greektax-deploy.env` is **not** committed — it lives on the cPanel host and holds `GREEKTAX_API_BASE=https://cntanos.pythonanywhere.com/api/v1`. The `set -a; . file; set +a` pattern exports every variable defined in the file. If the file is absent, the step is a no-op and the injector simply sees an unset env var.
- `configure_frontend.py` is a no-op when `GREEKTAX_API_BASE` is unset (per `tests/unit/test_configure_frontend.py::test_empty_api_base_on_clean_file_is_a_noop`), so merging this PR before the server-side file exists will not break the deploy — it will just leave the docroot `index.html` in its default same-origin state, which is the current behaviour.

## Server-side setup required after merge

On the cPanel host, once:

```bash
cat > ~/.greektax-deploy.env <<EOF2
GREEKTAX_API_BASE=https://cntanos.pythonanywhere.com/api/v1
EOF2
chmod 600 ~/.greektax-deploy.env
```

(`chmod 600` is hygiene, not strictly required — the value isn't a credential.)

After the file exists, every subsequent cPanel git deploy will rewrite `$DEPLOYPATH/index.html` to include the meta tag.

## Immediate one-shot fix (no redeploy needed)

You can fix the live site right now without waiting for the next deploy. From a cPanel Terminal session (or SSH), run from the cloned repo directory — typically `~/repositories/greektax` for cPanel git checkouts:

```bash
GREEKTAX_API_BASE=https://cntanos.pythonanywhere.com/api/v1 \
    python3 scripts/configure_frontend.py \
    --target "$HOME/public_html/wp-content/uploads/greektax/index.html"
```

(If your repo lives somewhere other than `~/repositories/greektax`, adjust accordingly.) That writes the meta tag into the currently-served `index.html`. Hard-reload the page and `resolveApiBase()` will return the PythonAnywhere URL.

## Verification

- [x] `.cpanel.yml` still valid YAML
- [ ] Server-side: create `~/.greektax-deploy.env`, push to trigger a deploy, verify the deployed `index.html` contains the injected block
- [ ] After deploy, the form populates from `cntanos.pythonanywhere.com/api/v1/config/years` instead of 404'ing on `cognisys.gr/api/v1/config/years`

## Apologies

This should have been one PR with #231, not two. The injector script alone shipped half the fix.
