### PR TITLE
Backport configure_frontend.py to Python 3.6 (cPanel deploy host)

### DIFF
--- a/scripts/configure_frontend.py
+++ b/scripts/configure_frontend.py
@@ -22,13 +22,12 @@ Exit codes:
     1 on usage/IO errors
 """
 
-from __future__ import annotations
-
 import argparse
 import os
 import re
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 MARKER_OPEN = "<!-- @greektax/api-base:start -->"
 MARKER_CLOSE = "<!-- @greektax/api-base:end -->"
@@ -74,7 +73,7 @@ def configure(target: Path, api_base: str) -> str:
     return f"injected data-api-base={api_base}"
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Inject GREEKTAX_API_BASE into a deployed index.html.",
     )


### PR DESCRIPTION
## Summary

The cPanel deploy host runs `python3 == 3.6`, which rejected the script's `from __future__ import annotations` (PEP 563, added in 3.7) and crashed the deploy with:

```
File "scripts/configure_frontend.py", line 25
    from __future__ import annotations
    ^
SyntaxError: future feature annotations is not defined
Task completed with exit code 1.
```

Result: every deploy since PR #232 merged has been completing the file-copy step and then failing the injector step, leaving the served `index.html` without the `<meta data-api-base>` tag. So the live site has been falling back to same-origin `/api/v1` → WordPress 404.

This PR backports the script to Python 3.6:

```diff
-from __future__ import annotations
-
 import argparse
 ...
+from typing import List, Optional
...
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
```

The script does no runtime introspection of annotations, so removing the future import and rewriting the one PEP-604 union as `Optional[List[str]]` is sufficient.

## Why backport rather than pin a newer Python in `.cpanel.yml`

- Hardcoding `/opt/cpanel/ea-python311/bin/python3` (or similar) couples the deploy to a specific EasyApache build that can change across host upgrades.
- The script is too small to deserve a hardcoded interpreter path — it's a 100-line text injector with no real Python-3.7+ dependencies.
- Backporting makes the deploy resilient to *any* host with Python ≥ 3.6, including future hosts.

## Verification

- [x] `ast.parse(open('scripts/configure_frontend.py').read(), feature_version=(3, 6))` — parses cleanly as Python 3.6
- [x] `pytest tests/unit/test_configure_frontend.py` — 8/8 still pass on the local interpreter (3.11)
- [x] `ruff check scripts/configure_frontend.py` clean
- [ ] After merge + redeploy, cPanel deploy log shows the injector task completing with exit code 0 and the served `index.html` contains the `<!-- @greektax/api-base:start -->` block
- [ ] Live site issues `GET https://cntanos.pythonanywhere.com/api/v1/config/years` instead of 404'ing on `cognisys.gr/api/v1/config/years`

## Apologies

The script should have been written for Python 3.6 to begin with. The `from __future__ import annotations` line was reflexive and I didn't think about deploy-host compatibility.
