### PR TITLE
Restore Sankey/Plotly module state lost in PR #221 refactor

### DIFF
--- a/src/frontend/assets/scripts/ui/app.js
+++ b/src/frontend/assets/scripts/ui/app.js
@@ -61,6 +61,13 @@ let pendingCalculatorState = null;
 let calculatorStatePersistHandle = null;
 let hasAppliedThemeOnce = false;
 let themeTransitionHandle = null;
+let plotlyLoaderPromise = null;
+let pendingPlotlyJob = null;
+let chartLibraryWarningShown = false;
+let sankeyRenderSequence = 0;
+let sankeyPlotlyRef = null;
+let sankeyResizeObserver = null;
+let sankeyWindowResizeHandler = null;
 let isApplyingYearMetadata = false;
 let partialYearWarningActive = false;
 let hasPendingFormChanges = false;
@@ -94,6 +101,20 @@ const EMPLOYMENT_CONTRIBUTION_PREVIEW_MESSAGES = {
       el: "Χρησιμοποιείται το ποσό που καταχωρήσατε: {{amount}} ετησίως.",
     },
   },
+};
+
+const DISTRIBUTION_CATEGORIES = [
+  { key: "net_income", colorVar: "--flow-net" },
+  { key: "taxes", colorVar: "--flow-taxes" },
+  { key: "insurance", colorVar: "--flow-contributions" },
+  { key: "expenses", colorVar: "--flow-expenses" },
+];
+
+const DISTRIBUTION_FALLBACK_COLORS = {
+  net_income: "#0f6dff",
+  taxes: "#ff4d6a",
+  insurance: "#00bfa6",
+  expenses: "#f5a524",
 };
 
 function buildCalculatorFormNameUsage() {


### PR DESCRIPTION
## Summary

The Sankey diagram never rendered after a calculation. Console:

```
ReferenceError: sankeyRenderSequence is not defined
```

Same fingerprint as PRs #228 and #229: PR #221's modular refactor (commit `353cdfc`) dropped module-level declarations from the new `ui/app.js` while keeping the reference sites that consumed them. Until now this batch had escaped detection because my earlier AST sweep checked only call expressions (`fn()`), not all identifier references. `sankeyRenderSequence` is a counter accessed via `++` and `===`, so it wasn't flagged.

I re-ran a tighter sweep that checks every `Identifier` reference (reads, writes, update expressions, member-object positions, etc.) against `app.js`. It surfaced **nine** missing declarations from the same refactor — all restored here.

## What changed

Two blocks added to `src/frontend/assets/scripts/ui/app.js`, sourced verbatim from `353cdfc^:src/frontend/assets/scripts/main.js`:

```js
// next to the other top-level state (around line 60)
let plotlyLoaderPromise = null;          // main.js line 87
let pendingPlotlyJob = null;             // main.js line 88
let chartLibraryWarningShown = false;    // main.js line 89
let sankeyRenderSequence = 0;            // main.js line 90
let sankeyPlotlyRef = null;              // main.js line 91
let sankeyResizeObserver = null;         // main.js line 92
let sankeyWindowResizeHandler = null;    // main.js line 93
```

```js
// next to EMPLOYMENT_CONTRIBUTION_PREVIEW_MESSAGES (around line 100)
const DISTRIBUTION_CATEGORIES = [...];        // main.js line 3917
const DISTRIBUTION_FALLBACK_COLORS = {...};   // main.js line 3924
```

## Verification

- [x] AST sweep (improved to cover all Identifier references): `OK: no undeclared identifier references in app.js`
- [x] JSDOM smoke test of `bootstrapApp()`: still completes, logs `GreekTax interface initialised`
- [x] `node --test tests/frontend/*.test.js` — 8/8 pass
- [x] File-size guardrail still satisfied (5703 → 5724 lines, budget 5800)
- [ ] After deploy: `https://www.cognisys.gr/greektax/` produces a Sankey diagram on Calculate without `ReferenceError`

## Why the original sweep missed this

The sweep I wrote during PR #229 only checked:

```js
node.type === "CallExpression" && node.callee.type === "Identifier"
```

That catches `foo()` but not:
- `++sankeyRenderSequence` (UpdateExpression)
- `renderToken !== sankeyRenderSequence` (BinaryExpression operand)
- `DISTRIBUTION_CATEGORIES.map(...)` (MemberExpression object)

The improved sweep walks every node, tracks lexical scopes (function/block/catch/for), and skips identifiers in binding positions (declarators, params, imports, member property names, non-shorthand property keys). It now reports clean against `app.js`.

## Follow-ups (NOT in this PR)

1. **Promote the sweep to a tracked CI check.** The improved sweep lives at `scripts/_smoke_find_undefined.mjs` (untracked). Wiring it into `tests/frontend/` would close this regression class permanently. Two open questions before doing so: (a) the sweep needs `acorn` (~50KB), so `package.json` would gain a dev dep; (b) CI would need a `npm install` step. Worth a small follow-up PR.
2. **Edge-specific data-fetch failure.** User reports Chrome and Firefox load data fine but Microsoft Edge does not. Tracking separately; needs Edge DevTools network/console output before I can pin it down.
