### PR TITLE
Cache-bust the deployed JS bundle by appending ?v=<hash>

### DIFF
--- a/scripts/configure_frontend.py
+++ b/scripts/configure_frontend.py
@@ -1,28 +1,36 @@
 #!/usr/bin/env python3
 """Inject deployment-specific configuration into the served frontend.
 
-Reads ``GREEKTAX_API_BASE`` from the environment and injects a
-``<meta data-api-base="..." />`` tag into a deployed ``index.html`` so the
-frontend points its API calls at the right backend host. The source
-``src/frontend/index.html`` stays deployment-agnostic.
+Two responsibilities, both run from a deploy hook after the static files
+have been copied into the docroot:
 
-Intended to run from a deploy hook (cPanel ``.cpanel.yml``, GitHub
-Actions, etc.) after the static files have been placed in the docroot.
-Re-running is safe: any previous injection is replaced. When the env
-var is unset or empty, any previous injection is removed so the
-frontend falls back to its same-origin default.
+1. **API base injection.** Reads ``GREEKTAX_API_BASE`` from the environment
+   and writes a ``<meta data-api-base="..." />`` tag into the deployed
+   ``index.html`` so the frontend talks to the right backend host.
+2. **Cache-buster versioning.** Computes a short content hash from every
+   JavaScript file under ``<docroot>/assets/scripts/`` and appends
+   ``?v=<hash>`` to (a) the ``<script type="module" src="...">`` tag in
+   ``index.html`` and (b) every relative ``import`` / ``export ... from``
+   in those JS files. When the bundle content changes, the hash changes,
+   so the browser fetches the new files instead of serving stale ones
+   from its long-lived ``immutable`` cache.
+
+Both steps are idempotent: any previous injection or version query is
+stripped before the new one is written, so re-running the script after a
+no-op deploy produces the same output as the first run.
 
 Usage::
 
     GREEKTAX_API_BASE=https://example.com/api/v1 \\
-        python scripts/configure_frontend.py --target /path/to/index.html
+        python3 scripts/configure_frontend.py --target /path/to/index.html
 
 Exit codes:
-    0 on success (including the env-unset cleanup path)
+    0 on success (including no-op paths)
     1 on usage/IO errors
 """
 
 import argparse
+import hashlib
 import os
 import re
 import sys
@@ -37,6 +45,18 @@ INJECTION_PATTERN = re.compile(
 )
 HEAD_CLOSE = "</head>"
 
+# Match `"..."` or `'...'` containing a relative path ending in `.js`,
+# with an optional pre-existing `?v=<hash>` query.
+JS_IMPORT_PATH_PATTERN = re.compile(
+    r"""(?P<quote>["'])(?P<path>\.{1,2}/[^"'?\s]*\.js)(?:\?v=[A-Za-z0-9]+)?(?P=quote)"""
+)
+
+# Match the loader script tag in index.html, optionally already versioned.
+SCRIPT_TAG_PATTERN = re.compile(
+    r"""(?P<prefix><script\b[^>]*?src=")(?P<path>\./assets/scripts/main\.js)"""
+    r"""(?:\?v=[A-Za-z0-9]+)?(?P<suffix>"[^>]*></script>)"""
+)
+
 
 def _strip_previous(html: str) -> str:
     return INJECTION_PATTERN.sub("", html)
@@ -44,18 +64,14 @@ def _strip_previous(html: str) -> str:
 
 def _build_block(api_base: str) -> str:
     return (
-        f"    {MARKER_OPEN}\n"
-        f'    <meta data-api-base="{api_base}" />\n'
-        f"    {MARKER_CLOSE}\n  "
+        "    " + MARKER_OPEN + "\n"
+        '    <meta data-api-base="' + api_base + '" />\n'
+        "    " + MARKER_CLOSE + "\n  "
     )
 
 
 def configure(target: Path, api_base: str) -> str:
-    """Inject (or remove) the meta tag in ``target``.
-
-    Returns a short status string for logging. Raises ``RuntimeError``
-    if the target lacks a ``</head>`` tag and an injection is needed.
-    """
+    """Inject (or remove) the meta tag in ``target``."""
     html = target.read_text(encoding="utf-8")
     stripped = _strip_previous(html)
 
@@ -67,15 +83,103 @@ def configure(target: Path, api_base: str) -> str:
 
     head_idx = stripped.find(HEAD_CLOSE)
     if head_idx == -1:
-        raise RuntimeError(f"could not find {HEAD_CLOSE!r} in {target}")
+        raise RuntimeError("could not find " + repr(HEAD_CLOSE) + " in " + str(target))
     new_html = stripped[:head_idx] + _build_block(api_base) + stripped[head_idx:]
     target.write_text(new_html, encoding="utf-8")
-    return f"injected data-api-base={api_base}"
+    return "injected data-api-base=" + api_base
+
+
+def _strip_versions_in_js(text: str) -> str:
+    return JS_IMPORT_PATH_PATTERN.sub(
+        lambda m: m.group("quote") + m.group("path") + m.group("quote"),
+        text,
+    )
+
+
+def _strip_version_in_script_tag(text: str) -> str:
+    return SCRIPT_TAG_PATTERN.sub(
+        lambda m: m.group("prefix") + m.group("path") + m.group("suffix"),
+        text,
+    )
+
+
+def _apply_version_to_js(text: str, version: str) -> str:
+    return JS_IMPORT_PATH_PATTERN.sub(
+        lambda m: (
+            m.group("quote") + m.group("path") + "?v=" + version + m.group("quote")
+        ),
+        text,
+    )
+
+
+def _apply_version_to_script_tag(text: str, version: str) -> str:
+    return SCRIPT_TAG_PATTERN.sub(
+        lambda m: (
+            m.group("prefix") + m.group("path") + "?v=" + version + m.group("suffix")
+        ),
+        text,
+    )
+
+
+def version_bundle(target: Path) -> str:
+    """Append ``?v=<hash>`` to every relative import and to the loader tag.
+
+    The hash is the first 12 hex chars of the SHA-256 over every JS file
+    under ``<target.parent>/assets/scripts/`` (sorted by relative path,
+    after stripping any existing ``?v=...`` from import statements). The
+    same hash is then appended to all relative imports and to the
+    ``<script type="module" src="...">`` tag in ``target``.
+
+    Returns a status string. If the scripts directory does not exist,
+    returns a short message and makes no changes (this is the common
+    case when running against a test fixture or unconfigured target).
+    """
+    scripts_dir = target.parent / "assets" / "scripts"
+    if not scripts_dir.is_dir():
+        return "skipped version_bundle: " + str(scripts_dir) + " not present"
+
+    js_files = sorted(
+        scripts_dir.rglob("*.js"),
+        key=lambda p: p.relative_to(scripts_dir).as_posix(),
+    )
+    if not js_files:
+        return "skipped version_bundle: no .js files under " + str(scripts_dir)
+
+    # Strip any pre-existing ?v=... so the hash is content-stable.
+    cleaned_sources = {}
+    for path in js_files:
+        original = path.read_text(encoding="utf-8")
+        cleaned = _strip_versions_in_js(original)
+        cleaned_sources[path] = cleaned
+
+    digest = hashlib.sha256()
+    for path in js_files:
+        rel = path.relative_to(scripts_dir).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(cleaned_sources[path].encode("utf-8"))
+    version = digest.hexdigest()[:12]
+
+    rewrites = 0
+    for path, cleaned in cleaned_sources.items():
+        versioned = _apply_version_to_js(cleaned, version)
+        if versioned != path.read_text(encoding="utf-8"):
+            path.write_text(versioned, encoding="utf-8")
+            rewrites += 1
+
+    html = target.read_text(encoding="utf-8")
+    html_clean = _strip_version_in_script_tag(html)
+    html_versioned = _apply_version_to_script_tag(html_clean, version)
+    if html_versioned != html:
+        target.write_text(html_versioned, encoding="utf-8")
+        rewrites += 1
+
+    return "versioned " + str(len(js_files)) + " JS files + index.html with ?v=" + version
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Inject GREEKTAX_API_BASE into a deployed index.html.",
+        description="Inject GREEKTAX_API_BASE and cache-buster version into a deployed index.html.",
     )
     parser.add_argument(
         "--target",
@@ -88,14 +192,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     api_base = (os.environ.get("GREEKTAX_API_BASE") or "").strip()
 
     if not args.target.exists():
-        print(f"error: {args.target} does not exist", file=sys.stderr)
+        print("error: " + str(args.target) + " does not exist", file=sys.stderr)
         return 1
     try:
         status = configure(args.target, api_base)
     except RuntimeError as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        print("error: " + str(exc), file=sys.stderr)
         return 1
     print(status)
+    try:
+        bundle_status = version_bundle(args.target)
+    except RuntimeError as exc:
+        print("error: " + str(exc), file=sys.stderr)
+        return 1
+    print(bundle_status)
     return 0
 
 

--- a/tests/unit/test_configure_frontend.py
+++ b/tests/unit/test_configure_frontend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -120,3 +121,122 @@ def test_main_with_unset_env_var_is_clean_noop(
 
     assert rc == 0
     assert target.read_text(encoding="utf-8") == HTML
+
+
+# ---- version_bundle tests ----
+
+VERSIONED_HTML = (
+    "<!DOCTYPE html>\n"
+    "<html><head>\n"
+    "<title>GreekTax</title>\n"
+    "</head><body>\n"
+    '<script type="module" src="./assets/scripts/main.js"></script>\n'
+    "</body></html>\n"
+)
+
+
+def _stage_bundle(tmp_path: Path) -> Path:
+    target = tmp_path / "index.html"
+    target.write_text(VERSIONED_HTML, encoding="utf-8")
+    scripts = tmp_path / "assets" / "scripts"
+    (scripts / "ui").mkdir(parents=True)
+    (scripts / "main.js").write_text(
+        'import { bootstrapApp } from "./ui/app.js";\n'
+        "bootstrapApp();\n",
+        encoding="utf-8",
+    )
+    (scripts / "ui" / "app.js").write_text(
+        'import { x } from "../helpers.js";\n'
+        "export function bootstrapApp() { return x; }\n",
+        encoding="utf-8",
+    )
+    (scripts / "helpers.js").write_text(
+        "export const x = 1;\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def test_version_bundle_appends_versions_to_html_and_imports(tmp_path: Path) -> None:
+    target = _stage_bundle(tmp_path)
+
+    status = configure_frontend.version_bundle(target)
+
+    assert "versioned" in status
+    html = target.read_text(encoding="utf-8")
+    main_js = (tmp_path / "assets" / "scripts" / "main.js").read_text("utf-8")
+    app_js = (tmp_path / "assets" / "scripts" / "ui" / "app.js").read_text("utf-8")
+    helpers = (tmp_path / "assets" / "scripts" / "helpers.js").read_text("utf-8")
+
+    # HTML script tag gains a version.
+    assert re.search(r'src="\./assets/scripts/main\.js\?v=[A-Za-z0-9]+"', html)
+    # main.js's relative import gains a version.
+    assert re.search(r'from "\./ui/app\.js\?v=[A-Za-z0-9]+"', main_js)
+    # app.js's relative import gains a version.
+    assert re.search(r'from "\.\./helpers\.js\?v=[A-Za-z0-9]+"', app_js)
+    # helpers.js has no relative imports — should be untouched.
+    assert helpers == "export const x = 1;\n"
+
+
+def test_version_bundle_is_idempotent(tmp_path: Path) -> None:
+    target = _stage_bundle(tmp_path)
+
+    configure_frontend.version_bundle(target)
+    after_first = target.read_text(encoding="utf-8")
+    main_first = (tmp_path / "assets" / "scripts" / "main.js").read_text("utf-8")
+
+    configure_frontend.version_bundle(target)
+    after_second = target.read_text(encoding="utf-8")
+    main_second = (tmp_path / "assets" / "scripts" / "main.js").read_text("utf-8")
+
+    assert after_first == after_second
+    assert main_first == main_second
+    # Exactly one ?v= per import, not stacked.
+    assert main_first.count("?v=") == 1
+
+
+def test_version_bundle_changes_when_content_changes(tmp_path: Path) -> None:
+    target = _stage_bundle(tmp_path)
+    configure_frontend.version_bundle(target)
+    html_before = target.read_text(encoding="utf-8")
+    match_before = re.search(r"main\.js\?v=([A-Za-z0-9]+)", html_before)
+    assert match_before
+    version_before = match_before.group(1)
+
+    # Modify a JS file and re-run.
+    helpers = tmp_path / "assets" / "scripts" / "helpers.js"
+    helpers.write_text("export const x = 2;\n", encoding="utf-8")
+    configure_frontend.version_bundle(target)
+    html_after = target.read_text(encoding="utf-8")
+    match_after = re.search(r"main\.js\?v=([A-Za-z0-9]+)", html_after)
+    assert match_after
+    version_after = match_after.group(1)
+
+    assert version_before != version_after
+
+
+def test_version_bundle_skips_when_scripts_dir_missing(tmp_path: Path) -> None:
+    target = tmp_path / "index.html"
+    target.write_text(VERSIONED_HTML, encoding="utf-8")
+
+    status = configure_frontend.version_bundle(target)
+
+    assert "skipped" in status
+    # File is unchanged.
+    assert target.read_text(encoding="utf-8") == VERSIONED_HTML
+
+
+def test_main_runs_both_steps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _stage_bundle(tmp_path)
+    monkeypatch.setenv("GREEKTAX_API_BASE", "https://api.example.com/v1")
+
+    rc = configure_frontend.main(["--target", str(target)])
+
+    assert rc == 0
+    html = target.read_text(encoding="utf-8")
+    # API base meta tag.
+    assert '<meta data-api-base="https://api.example.com/v1" />' in html
+    # Cache-bust query.
+    assert re.search(r'src="\./assets/scripts/main\.js\?v=[A-Za-z0-9]+"', html)


### PR DESCRIPTION
## Summary

The cPanel deploy serves `assets/scripts/*.js` with `Cache-Control: public, max-age=31536000, immutable`. Edge — which honours `immutable` more strictly than Chrome or Firefox — kept replaying a stale `app.js` after recent deploys, producing the original `ReferenceError: hasAppliedThemeOnce is not defined` even though the deployed file on the server *did* contain the declaration. Confirmed by:

- Fetching the bundle from cognisys.gr with Edge, Chrome, and Firefox user agents and finding the bytes are identical (`hash=f68b223ee219b0cc`, both serve `let hasAppliedThemeOnce = false`).
- Edge's console reported the error at lines `1330` and `5545`, which match the *pre-fix* line numbering — i.e. Edge was running cached old code while the network panel showed the current bundle as having loaded.

## Why script-tag versioning alone is insufficient

ES modules cache per resolved URL. Putting `?v=<hash>` on the `<script src="./assets/scripts/main.js">` reference only busts `main.js`; the `import "./ui/app.js"` inside `main.js` still resolves to the same URL the browser has cached. To actually cascade, the version has to land on every relative import too.

## What this PR does

Extends `scripts/configure_frontend.py` with a `version_bundle(target)` step. After the existing meta-tag injection, it:

1. Walks every `*.js` file under `<docroot>/assets/scripts/` (sorted by relative path).
2. Strips any pre-existing `?v=...` from `from "./x.js"` / `import("./x.js")` / `export ... from "./x.js"` patterns so the next step sees clean content.
3. Computes a SHA-256 over the concatenated `<relative-path>\0<cleaned-content>` for every JS file and takes the first 12 hex chars as the version.
4. Appends `?v=<version>` to every relative import in every JS file.
5. Appends `?v=<version>` to the `<script type="module" src="./assets/scripts/main.js">` tag in `index.html`.

The same hash is applied everywhere in a single deploy, so the browser fetches the entire module graph fresh when any JS file changes — and zero traffic when nothing changes.

## End-to-end verification (untracked smoke `scripts/_smoke_cache_bust_e2e.mjs`)

```
injected data-api-base=https://cntanos.pythonanywhere.com/api/v1
versioned 11 JS files + index.html with ?v=e2a3ff845127

HTML script tag versioned: true -> v=e2a3ff845127
main.js relative import versioned: true -> v=e2a3ff845127
app.js relative import versions found: 6
  - ../api/endpoints.js?v=e2a3ff845127
  - ../config/constants.js?v=e2a3ff845127
  - ../charts/distribution.js?v=e2a3ff845127
  - ../i18n/catalog.js?v=e2a3ff845127
  - ../state/i18nState.js?v=e2a3ff845127
  - ../validation/numbers.js?v=e2a3ff845127
unique versions across all rewrites: 1
OK: re-run produces the same v=e2a3ff845127
```

## Tests

- [x] `pytest tests/unit/test_configure_frontend.py` — 13/13 pass (8 existing + 5 new)
- [x] New cases: cascading version across HTML + JS imports, idempotency, version-changes-when-content-changes, scripts-dir-missing skip, combined `main()` entry point
- [x] `ruff` clean, `mypy src` clean
- [x] Python 3.6 syntax verified with `ast.parse(..., feature_version=(3, 6))`
- [x] No new dependencies — stdlib only (`hashlib`, `re`, `pathlib`)
- [ ] Post-deploy: Edge picks up the new bundle on first reload after deploy; `View source` on `cognisys.gr/greektax/` shows `<script type="module" src="./assets/scripts/main.js?v=...">`

## Caveats / scope notes

- **The first deploy after this merges will still hit the stale-cache problem in Edge.** The `?v=` only helps from the *next* deploy onward. For the immediate Edge issue, clear cache (Application tab → Storage → Clear site data) or open in InPrivate.
- **Service workers, if any are ever added later**, will need their own cache-busting strategy — `?v=` doesn't help SW-cached responses.
- **What this PR does NOT change**: server-side `Cache-Control` headers stay `immutable`. That's the desired state for content-addressed-style URLs.

## Follow-ups (NOT in this PR)

1. **Hashed filenames** — move to `main.<hash>.js` etc. so resources are truly content-addressed, eliminating *any* possibility of mid-deploy stale references. Bigger change; not needed today.
2. **Promote the live-site probe** (`scripts/_smoke_live_site.mjs`, untracked) into a small `tests/e2e/` smoke that checks the deployed bundle on every deploy. Out of scope here.
