### PR TITLE
Set baseline security headers and request-body size limit

### DIFF
--- a/src/greektax/backend/app/__init__.py
+++ b/src/greektax/backend/app/__init__.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 from flask import Flask, Response, jsonify, request, send_from_directory
 from flask.typing import ResponseReturnValue
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, RequestEntityTooLarge
 
 from .routes import register_routes
 
@@ -84,10 +84,40 @@ def _apply_default_cors_headers(
     return response
 
 
+DEFAULT_MAX_REQUEST_BYTES = 64 * 1024
+
+
+def _resolve_max_request_bytes() -> int:
+    raw = os.getenv("GREEKTAX_MAX_REQUEST_BYTES")
+    if raw is None:
+        return DEFAULT_MAX_REQUEST_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_REQUEST_BYTES
+    return value if value > 0 else DEFAULT_MAX_REQUEST_BYTES
+
+
+def _attach_security_headers(response: Response) -> Response:
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault(
+        "Referrer-Policy", "strict-origin-when-cross-origin"
+    )
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    if not request.path.startswith("/assets/"):
+        response.headers["Cache-Control"] = "no-store"
+    if request.headers.get("X-Forwarded-Proto") == "https":
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+    return response
+
+
 def create_app() -> Flask:
     """Create and configure the Flask application instance."""
 
     app = Flask(__name__)
+    app.config["MAX_CONTENT_LENGTH"] = _resolve_max_request_bytes()
 
     allowed_origins = _parse_allowed_origins(
         os.getenv("GREEKTAX_ALLOWED_ORIGINS")
@@ -157,10 +187,22 @@ def create_app() -> Flask:
         message = error.description or "Invalid request"
         return jsonify({"error": "bad_request", "message": message}), 400
 
+    @app.errorhandler(RequestEntityTooLarge)
+    def handle_too_large(error: RequestEntityTooLarge):
+        """Reject oversized request bodies with a structured response."""
+
+        return jsonify(
+            {"error": "payload_too_large", "message": "Request body too large."}
+        ), 413
+
     @app.errorhandler(ValueError)
     def handle_value_error(error: ValueError):
         """Gracefully surface domain validation errors to clients."""
 
         return jsonify({"error": "validation_error", "message": str(error)}), 400
+
+    @app.after_request
+    def _security_headers(response: Response) -> Response:
+        return _attach_security_headers(response)
 
     return app


### PR DESCRIPTION
## Summary

Implements two of the high-severity findings from the recent security review:

1. **Baseline security headers.** Adds an `after_request` hook in `create_app()` that emits four hardening headers on every response:
   - `X-Content-Type-Options: nosniff`
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `X-Frame-Options: DENY`
   - `Cache-Control: no-store` (on non-static responses only — static assets under `/assets/` keep their normal cache headers)

   Plus `Strict-Transport-Security: max-age=31536000; includeSubDomains` when the upstream proxy reports `X-Forwarded-Proto: https`.

2. **Request-body size limit.** Reads `GREEKTAX_MAX_REQUEST_BYTES` (default **64 KiB**) into `MAX_CONTENT_LENGTH`, and registers a `RequestEntityTooLarge` error handler that returns:

   ```json
   { "error": "payload_too_large", "message": "Request body too large." }
   ```

   with HTTP 413. Oversized JSON payloads were previously parsed in full before any validation, leaving the calculations endpoint with a cheap DoS surface (unbounded `dict[str, ...]` shape in the Pydantic model).

## Verification

- [x] `pytest`: 177/178 pass (was 174/178 before this PR — fixed 3 of the 4 previously-failing tests):
  - `tests/integration/test_security_headers.py::test_api_responses_include_security_headers` → **PASS**
  - `tests/integration/test_security_headers.py::test_secure_requests_include_hsts_header` → **PASS**
  - `tests/integration/test_request_limits.py::test_calculation_endpoint_rejects_oversized_payload` → **PASS**
- [x] `ruff check`, `mypy src` clean
- [x] No new dependencies
- [ ] After deploy: `curl -I -H 'X-Forwarded-Proto: https' https://cntanos.pythonanywhere.com/api/v1/config/meta` returns all four baseline headers + HSTS

## Why these are bound together

Both findings stem from the same root cause: contracts the tests express that the production code never implemented. Fixing them together keeps the change minimal (44 added lines in one file) and turns the CI red into CI green for these specific tests in one commit.

## Remaining red test (out of scope here)

`tests/e2e/test_smoke_flow.py::test_smoke_user_flow` still fails: it asserts `id="api-connection-status"` is present in the served HTML. That element exists nowhere in the codebase — `grep -r api-connection-status` returns only the test file itself, and `git log -S api-connection-status` returns no history. It's an aspirational test for a UI feature (API health badge) that was never built. Should be either:
- (a) implemented as a real connection-status indicator, or
- (b) the test should be deleted or marked `xfail`.

Either way, it's a UI/feature question rather than a security one. Tracking separately.

## Configuration notes

- `GREEKTAX_MAX_REQUEST_BYTES` accepts a positive integer. Non-numeric or non-positive values fall back to the 64 KiB default rather than erroring out — production deploys with a malformed value keep working.
- The 64 KiB default is comfortably above the largest realistic calculation payload (~3-4 KiB observed locally) while well below the kind of multi-MB blob that would actually hurt.
