### PR TITLE
Add Content Security Policy to the frontend shell

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,6 +62,24 @@ The injection sits inside `<!-- @greektax/api-base:start --> ... <!-- @greektax/
 
 For cPanel-based deploys, invoke the script from `.cpanel.yml` (or the equivalent post-deploy hook) after the static files have been copied into the docroot. CORS must permit the frontend origin → backend origin call; verify with a manual cross-origin fetch before relying on the deployed page.
 
+## Frontend Content Security Policy
+
+`src/frontend/index.html` carries a `<meta http-equiv="Content-Security-Policy">` tag with the following effective policy:
+
+| Directive | Value | Why |
+| --- | --- | --- |
+| `default-src` | `'self'` | Block all non-same-origin loads unless overridden below. |
+| `script-src` | `'self' https://cdn.plot.ly` | Allow the Plotly CDN bundle (pinned via SRI). |
+| `style-src` | `'self' 'unsafe-inline'` | Inline `element.style.X = ...` assignments inside `app.js` (chart layout, theming) need the `unsafe-inline` keyword. |
+| `img-src` | `'self' data:` | Plotly emits inline data-URI rasters for some icons. |
+| `connect-src` | `'self' https://*.pythonanywhere.com` | Allow XHR/fetch to any PythonAnywhere-hosted backend. Tighten to the exact host if you don't want the wildcard. |
+| `frame-ancestors` | `'none'` | Cannot be embedded in an iframe. |
+| `base-uri` | `'self'` | Lock `<base>` element. |
+| `form-action` | `'self'` | Prevent off-origin form posts. |
+| `object-src` | `'none'` | No Flash/plugin loads. |
+
+If you move the backend off `*.pythonanywhere.com`, replace the host token in `connect-src` and redeploy. CSP violations are reported by the browser as console errors with the directive that blocked the load.
+
 ## Year configuration refreshes
 
 When introducing or updating filing years in `src/greektax/backend/config/data/*.yaml`:

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -6,6 +6,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' https://cdn.plot.ly; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.pythonanywhere.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+    />
     <title>CogniSys-GreekTax</title>
     <link rel="stylesheet" href="./assets/styles/main.css" />
   </head>


### PR DESCRIPTION
## Summary

Closes the third high-severity item from the recent security audit: no Content Security Policy was set anywhere. A future XSS regression or a compromise of the Plotly CDN currently has no second line of defence; this PR adds one.

A `<meta http-equiv="Content-Security-Policy">` tag is added to `src/frontend/index.html`. Browsers parse it at HTML parse time, so it covers the entire page lifetime including the first render of any module.

```html
<meta
  http-equiv="Content-Security-Policy"
  content="default-src 'self'; script-src 'self' https://cdn.plot.ly; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.pythonanywhere.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
/>
```

## Each directive justified against what the page actually loads

| Directive | Value | Why |
| --- | --- | --- |
| `default-src` | `'self'` | Block everything not explicitly whitelisted below. |
| `script-src` | `'self' https://cdn.plot.ly` | Plotly is loaded from `cdn.plot.ly` (SRI-pinned at line 1467-1472). The two other `<script src>` tags are same-origin. |
| `style-src` | `'self' 'unsafe-inline'` | `element.style.X = ...` assignments inside `app.js` (chart layout, theming) write inline style attributes. Confirmed 10+ sites via `grep '\.style\.'`. |
| `img-src` | `'self' data:` | Plotly emits inline data-URI rasters for some icons. |
| `connect-src` | `'self' https://*.pythonanywhere.com` | Same-origin (local dev where backend is same-origin) and PythonAnywhere (production). The wildcard works for any PythonAnywhere tenant. |
| `frame-ancestors` | `'none'` | Defence against clickjacking; complements the `X-Frame-Options: DENY` header set by #236. |
| `base-uri` | `'self'` | Prevent `<base href>` hijacking. |
| `form-action` | `'self'` | Prevent off-origin form posts. |
| `object-src` | `'none'` | No Flash/plugin loads. |

`docs/operations.md` gains a section documenting these choices and how to tighten/extend for forks that target a different backend host.

## Why a wildcard for `connect-src`

The wildcard `https://*.pythonanywhere.com` keeps the canonical source deployment-agnostic — consistent with the earlier decision (PRs #229/#231) to not commit the specific PythonAnywhere username to the repo. A fork deploying to its own PythonAnywhere tenant works without editing the CSP; only deployments off-platform need a CSP edit.

If you want tighter, change to `https://cntanos.pythonanywhere.com` directly (and document the override in `operations.md`). That can be a one-line follow-up.

## Verification

- [x] JSDOM bootstrap smoke (`scripts/_smoke_bootstrap_jsdom.mjs`): module imports, `bootstrapApp()` returns, no errors related to the CSP-allowed sources. (JSDOM doesn't enforce CSP, so this only confirms HTML parsing is still correct.)
- [x] `node --test tests/frontend/*.test.js`: 8/8 pass.
- [x] Verified no inline scripts and no inline event handlers exist in `index.html` that the CSP would block. Only `<script src=...>` tags. Plotly script tag is at line 1467-1472 with SRI integrity.
- [x] Verified `element.style.X` assignments exist in `app.js` (10+ sites), justifying `'unsafe-inline'` for styles.
- [ ] After deploy: Edge / Chrome / Firefox DevTools Console shows no CSP-violation errors on page load, on Calculate, or on theme switch.

## What this doesn't do (deliberately)

- **No CSP nonce for inline styles.** Eliminating `'unsafe-inline'` would require either (a) moving inline style writes into a stylesheet (intrusive refactor) or (b) adding nonces at deploy time + plumbing them through the JS. Out of scope; the current `'unsafe-inline'` is a known concession that still blocks the vast majority of XSS patterns.
- **No CSP report-to / report-uri.** Adding violation reporting would help diagnose any false negatives after deploy. Worth a small follow-up once you've confirmed the policy doesn't break anything.

## Coupling note

This PR can be merged independently of #236 (backend headers) and #237 (CI hardening). The three together address all four high-severity audit findings.
