### PR TITLE
Fail fast in production when CORS allow-list is empty

### DIFF
--- a/src/greektax/backend/app/__init__.py
+++ b/src/greektax/backend/app/__init__.py
@@ -94,10 +94,15 @@ def create_app() -> Flask:
     )
 
     if not allowed_origins:
-        warn(
-            "No allowed origins configured; cross-origin requests will be rejected.",
-            stacklevel=1,
+        message = (
+            "No allowed origins configured; cross-origin requests will be rejected."
         )
+        if os.getenv("FLASK_ENV") == "production":
+            raise RuntimeError(
+                message
+                + " Set GREEKTAX_ALLOWED_ORIGINS or unset FLASK_ENV=production to start."
+            )
+        warn(message, stacklevel=1)
 
     if CORS is not None:
         CORS(

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -5,6 +5,28 @@ from flask.testing import FlaskClient
 
 from greektax.backend.app import create_app
 
+
+def test_create_app_fails_fast_without_origins_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When FLASK_ENV=production, missing allow-list must abort startup."""
+
+    monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.delenv("GREEKTAX_ALLOWED_ORIGINS", raising=False)
+    with pytest.raises(RuntimeError, match="GREEKTAX_ALLOWED_ORIGINS"):
+        create_app()
+
+
+def test_create_app_only_warns_outside_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside production, an empty allow-list still emits the legacy warning."""
+
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    monkeypatch.delenv("GREEKTAX_ALLOWED_ORIGINS", raising=False)
+    with pytest.warns(UserWarning, match="No allowed origins configured"):
+        create_app()
+
 ALLOWED_ORIGIN = "https://allowed.test"
 ALLOWED_EMBEDDER = "https://embedder.test"
 DISALLOWED_ORIGIN = "https://blocked.test"


### PR DESCRIPTION
## Summary

Closes the **Low #8** finding from the security audit. Previously `create_app()` only emitted a `warn()` when `GREEKTAX_ALLOWED_ORIGINS` was unset, then started the app with an empty allow-list — silently rejecting every cross-origin request. Operators frequently miss the single warning line in PythonAnywhere/server logs; the symptom on the client side looks like a network outage.

Now: when `FLASK_ENV=production` and no origins are configured, `create_app()` raises `RuntimeError` with a clear remediation message. Outside production the legacy `warn()` behaviour is preserved so local dev runs unchanged.

## Why it's opt-in

This is gated on `FLASK_ENV=production`. The PythonAnywhere host currently does **not** set `FLASK_ENV`, so this PR is a no-op on the existing deploy until you opt in — but it's wired up and ready to flip:

1. Set `GREEKTAX_ALLOWED_ORIGINS=https://www.cognisys.gr` on the PythonAnywhere host (you may already have this).
2. Add `FLASK_ENV=production`.
3. Next worker restart will refuse to boot if step 1 was missed.

Net effect: a future regression that drops the allow-list from the env will fail loudly at startup rather than silently in the field.

## Verification

- [x] `pytest tests/integration/test_cors.py` — 6/6 pass (4 existing + 2 new)
- [x] `pytest` overall — same pre-existing 4 failures as before (they pre-date this branch and are addressed by #236)
- [x] `ruff` and `mypy` clean
- [ ] After enabling in production: deliberately remove `GREEKTAX_ALLOWED_ORIGINS` and confirm the next worker reload fails with the new error message

## Code change

```python
if not allowed_origins:
    message = (
        "No allowed origins configured; cross-origin requests will be rejected."
    )
    if os.getenv("FLASK_ENV") == "production":
        raise RuntimeError(
            message
            + " Set GREEKTAX_ALLOWED_ORIGINS or unset FLASK_ENV=production to start."
        )
    warn(message, stacklevel=1)
```

Plus two tests covering both paths.
