### PR TITLE
Bump Plotly to 2.35.3 with fresh SRI hash

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1461,8 +1461,8 @@
     </footer>
 
     <script
-      src="https://cdn.plot.ly/plotly-2.26.0.min.js"
-      integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v+K+FrXxV4MlJHnWKgnaKoh74vd/6Ik8uF"
+      src="https://cdn.plot.ly/plotly-2.35.3.min.js"
+      integrity="sha384-MqL7Cy3itNqCI1Wlc926K0XhyRKJ/NMqTaytIIEB+QIdInOploxqRIHRKLlhPykM"
       crossorigin="anonymous"
       defer
     ></script>

--- a/tests/frontend/plotlyScriptPolicy.test.js
+++ b/tests/frontend/plotlyScriptPolicy.test.js
@@ -13,7 +13,7 @@ const appPath = resolve(__dirname, '../../src/frontend/assets/scripts/ui/app.js'
 
 test('index declares Plotly with pinned SRI and crossorigin', () => {
   const html = readFileSync(htmlPath, 'utf8');
-  const plotlyScriptPattern = /<script\s+[^>]*src="https:\/\/cdn\.plot\.ly\/plotly-2\.26\.0\.min\.js"[^>]*>/;
+  const plotlyScriptPattern = /<script\s+[^>]*src="https:\/\/cdn\.plot\.ly\/plotly-2\.35\.3\.min\.js"[^>]*>/;
   const match = html.match(plotlyScriptPattern);
 
   assert.ok(match, 'Expected a static Plotly script tag in index.html');
@@ -21,7 +21,7 @@ test('index declares Plotly with pinned SRI and crossorigin', () => {
 
   assert.match(
     tag,
-    /integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v\+K\+FrXxV4MlJHnWKgnaKoh74vd\/6Ik8uF"/,
+    /integrity="sha384-MqL7Cy3itNqCI1Wlc926K0XhyRKJ\/NMqTaytIIEB\+QIdInOploxqRIHRKLlhPykM"/,
     'Expected Plotly script tag to include the pinned SHA-384 integrity hash',
   );
   assert.match(
@@ -36,7 +36,7 @@ test('runtime scripts do not dynamically inject Plotly script URLs', () => {
 
   sources.forEach((source) => {
     assert.equal(
-      source.includes('cdn.plot.ly/plotly-2.26.0.min.js'),
+      source.includes('cdn.plot.ly/plotly-2.35.3.min.js'),
       false,
       'Runtime script source should not be hardcoded in runtime modules',
     );


### PR DESCRIPTION
## Summary

Closes **Low #9** from the security audit: Plotly 2.26.0 (September 2023) was 14+ months old. This bumps to **v2.35.3** (December 2024), the latest release in the 2.x line.

```diff
- src="https://cdn.plot.ly/plotly-2.26.0.min.js"
- integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v+K+FrXxV4MlJHnWKgnaKoh74vd/6Ik8uF"
+ src="https://cdn.plot.ly/plotly-2.35.3.min.js"
+ integrity="sha384-MqL7Cy3itNqCI1Wlc926K0XhyRKJ/NMqTaytIIEB+QIdInOploxqRIHRKLlhPykM"
```

## Why this version

- **2.35.3 is the latest 2.x release.** Plotly 3.x exists but is a major-version bump with breaking changes; out of scope for a security follow-up.
- **No breaking changes** documented in the upstream `CHANGELOG.md` for the range v2.27.0 → v2.35.3 (verified via WebFetch of the raw changelog).
- **Sankey-trace changes are purely additive** in that range: new `align` option (2.28), custom link-hover styles (2.29), arrow support (2.31), `zorder` for overlaying cartesians (2.34). Nothing the GreekTax chart code uses was deprecated or removed.
- **No CVE applies.** The only Plotly CVE in the changelog is CVE-2025-7783 (via the `form-data` transitive), introduced and fixed within the 3.x line — doesn't touch 2.x at all.

## SRI verification

The new integrity hash was computed by streaming the file from `cdn.plot.ly` into Python and hashing with SHA-384 + base64. Re-running the fetch produced identical bytes, so the integrity attribute is stable across CDN edges.

```
$ curl -s "https://cdn.plot.ly/plotly-2.35.3.min.js" | \
    python -c "import sys, hashlib, base64; print('sha384-' + base64.b64encode(hashlib.sha384(sys.stdin.buffer.read()).digest()).decode())"
sha384-MqL7Cy3itNqCI1Wlc926K0XhyRKJ/NMqTaytIIEB+QIdInOploxqRIHRKLlhPykM
```

## Tests

- [x] `tests/frontend/plotlyScriptPolicy.test.js` updated in lockstep (it hardcoded the previous version + integrity string)
- [x] `node --test tests/frontend/*.test.js` — 8/8 pass
- [ ] After deploy: Sankey diagram renders on Calculate with no console errors; if the SRI mismatches anything, the browser will block the script and Plotly will be undefined (would manifest as `Plotly is not defined` errors from `app.js`)

## Coupling

Independent of the other open security PRs (#236, #237, #238, #239). Can merge in any order.
