### PR TITLE
Cache-bust every ./assets/scripts/*.js script tag, not just main.js

### DIFF
--- a/scripts/configure_frontend.py
+++ b/scripts/configure_frontend.py
@@ -51,9 +51,11 @@ JS_IMPORT_PATH_PATTERN = re.compile(
     r"""(?P<quote>["'])(?P<path>\.{1,2}/[^"'?\s]*\.js)(?:\?v=[A-Za-z0-9]+)?(?P=quote)"""
 )
 
-# Match the loader script tag in index.html, optionally already versioned.
+# Match any local script tag in index.html, optionally already versioned.
+# Covers both the ES-module entrypoint (./assets/scripts/main.js) and any
+# classic-script siblings such as ./assets/scripts/translations.generated.js.
 SCRIPT_TAG_PATTERN = re.compile(
-    r"""(?P<prefix><script\b[^>]*?src=")(?P<path>\./assets/scripts/main\.js)"""
+    r"""(?P<prefix><script\b[^>]*?src=")(?P<path>\./assets/scripts/[^"?\s]+\.js)"""
     r"""(?:\?v=[A-Za-z0-9]+)?(?P<suffix>"[^>]*></script>)"""
 )
 

--- a/tests/unit/test_configure_frontend.py
+++ b/tests/unit/test_configure_frontend.py
@@ -130,6 +130,7 @@ VERSIONED_HTML = (
     "<html><head>\n"
     "<title>GreekTax</title>\n"
     "</head><body>\n"
+    '<script src="./assets/scripts/translations.generated.js" defer></script>\n'
     '<script type="module" src="./assets/scripts/main.js"></script>\n'
     "</body></html>\n"
 )
@@ -140,6 +141,10 @@ def _stage_bundle(tmp_path: Path) -> Path:
     target.write_text(VERSIONED_HTML, encoding="utf-8")
     scripts = tmp_path / "assets" / "scripts"
     (scripts / "ui").mkdir(parents=True)
+    (scripts / "translations.generated.js").write_text(
+        "window.__GREEKTAX_EMBEDDED_TRANSLATIONS__ = {};\n",
+        encoding="utf-8",
+    )
     (scripts / "main.js").write_text(
         'import { bootstrapApp } from "./ui/app.js";\n'
         "bootstrapApp();\n",
@@ -168,8 +173,18 @@ def test_version_bundle_appends_versions_to_html_and_imports(tmp_path: Path) -> 
     app_js = (tmp_path / "assets" / "scripts" / "ui" / "app.js").read_text("utf-8")
     helpers = (tmp_path / "assets" / "scripts" / "helpers.js").read_text("utf-8")
 
-    # HTML script tag gains a version.
-    assert re.search(r'src="\./assets/scripts/main\.js\?v=[A-Za-z0-9]+"', html)
+    # ES-module entrypoint gains a version.
+    main_match = re.search(
+        r'src="\./assets/scripts/main\.js\?v=([A-Za-z0-9]+)"', html
+    )
+    assert main_match
+    # Classic-script sibling (translations.generated.js) gains the same version.
+    translations_match = re.search(
+        r'src="\./assets/scripts/translations\.generated\.js\?v=([A-Za-z0-9]+)"',
+        html,
+    )
+    assert translations_match
+    assert main_match.group(1) == translations_match.group(1)
     # main.js's relative import gains a version.
     assert re.search(r'from "\./ui/app\.js\?v=[A-Za-z0-9]+"', main_js)
     # app.js's relative import gains a version.


### PR DESCRIPTION
## Summary

Bug surfaced after PR #241 deploy: the new `actions.remember_entries` label flashed its inline HTML default ("Remember my entries on this device") for ~100 ms, then `localiseStaticText()` overwrote it with the literal key `"actions.remember_entries"`.

Root cause: `translations.generated.js` is a classic non-module script (it sets `window.__GREEKTAX_EMBEDDED_TRANSLATIONS__` and is read by `app.js`'s `seedEmbeddedTranslations()`). It's served from the same `Cache-Control: public, max-age=31536000, immutable` directory as everything else, but PR #235's cache-bust regex only matched **`main.js`** — so on deploy, `main.js?v=newhash` was fetched fresh while `translations.generated.js` was served from the long-lived cache. The fresh code looked up a key that the stale embedded payload didn't have.

## What this PR does

Generalise `SCRIPT_TAG_PATTERN` in `scripts/configure_frontend.py` from `./assets/scripts/main.js` to `./assets/scripts/<anything>.js`:

```diff
-r"""(?P<path>\./assets/scripts/main\.js)"""
+r"""(?P<path>\./assets/scripts/[^"?\s]+\.js)"""
```

Effect: `re.sub` now applies the same version query to every local script tag in `index.html`. Plotly's `https://cdn.plot.ly/...` script tag is unaffected because its URL doesn't start with `./assets/scripts/`.

## Test fixture

The fixture HTML in `tests/unit/test_configure_frontend.py` gained a second `<script src>` tag plus a stub `translations.generated.js`, and the existing `test_version_bundle_appends_versions_to_html_and_imports` now asserts:

1. Both script tags carry a `?v=…` query.
2. Both versions are equal — derived from the same content hash.

```
✓ tests/unit/test_configure_frontend.py — 13/13 pass
```

## End-to-end verification

```bash
$ GREEKTAX_API_BASE=https://example.com/api/v1 \
    python scripts/configure_frontend.py --target $tmp/index.html
injected data-api-base=https://example.com/api/v1
versioned 11 JS files + index.html with ?v=e57eab8fe9fb

$ grep -oE 'src="\./assets/scripts/[^"]*\.js[^"]*"' $tmp/index.html
src="./assets/scripts/translations.generated.js?v=e57eab8fe9fb"
src="./assets/scripts/main.js?v=e57eab8fe9fb"
```

## After merge

1. Merge this PR.
2. Trigger a cPanel deploy.
3. Hard-reload `cognisys.gr/greektax/`. The translations.generated.js URL in the Network tab should carry `?v=…`. The "Remember my entries on this device" label should render in Greek (or English) and stay.

If a user has the stale `translations.generated.js` cached from before this PR, the new HTML referencing `translations.generated.js?v=…` will force a fresh fetch on first load — the bug self-heals.
