### PR TITLE
Add Claude-based automated PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,71 @@
+name: Claude PR Review
+
+# Runs Claude (via anthropics/claude-code-action) against every PR opened
+# or updated, posting a single review comment. No @claude mention needed —
+# the action infers PR context from the trigger.
+#
+# Setup requirements (see PR description):
+#   1. Install the Claude GitHub App on this repository.
+#   2. Add an `ANTHROPIC_API_KEY` repository secret.
+#   3. (Optional) Disable the previous AI reviewer (OpenAI Codex) at
+#      https://chatgpt.com/codex/cloud/settings/general.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip drafts so we only spend tokens on PRs that are ready for review.
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Full history so Claude can inspect base...head diffs accurately.
+          fetch-depth: 0
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          prompt: |
+            You are reviewing a pull request against the GreekTax repository
+            (a Greek tax calculator: Python/Flask backend + static JS
+            frontend, no auth, no PII storage, no DB). Be terse and
+            actionable.
+
+            Focus on:
+            - Correctness of the changed logic, especially edge cases around
+              the Pydantic models in src/greektax/backend/app/models/ and the
+              Sankey/distribution rendering path in
+              src/frontend/assets/scripts/ui/app.js.
+            - Security: input validation on API routes, XSS surfaces in JS
+              (textContent vs innerHTML), localStorage usage, CSP/CORS
+              regressions, secret hygiene in workflows.
+            - Test coverage for new branches.
+            - Adherence to the existing patterns (see docs/architecture.md
+              and CLAUDE.md) — avoid suggesting refactors outside the PR's
+              scope.
+
+            Skip:
+            - Style nits already enforced by ruff/mypy.
+            - Hypothetical generality. This is a single-deployment project.
+
+            Format the review as:
+            - A 1-2 sentence summary of what the PR does.
+            - A bulleted list of findings, each tagged [bug] / [security]
+              / [perf] / [test] / [nit]. Cite file:line for each.
+            - Final verdict: "Ready", "Address findings then merge", or
+              "Needs rework".


### PR DESCRIPTION
## Summary

Replaces the current OpenAI Codex auto-reviewer (configured via the external chatgpt.com SaaS dashboard) with Claude via `anthropics/claude-code-action@v1`, owned as code in this repository.

The workflow lives at `.github/workflows/claude-code-review.yml` and fires on `pull_request` events (`opened`, `synchronize`, `reopened`, `ready_for_review`). It skips draft PRs, scopes `GITHUB_TOKEN` to the minimum permissions needed to post a review (`contents: read`, `pull-requests: write`, `issues: write`), and uses a concurrency group keyed on the PR number so updating a PR cancels any in-flight review for the older commit.

## Prompt design

The prompt is tailored to this repo:

- **Focus**: correctness of changed logic (especially Pydantic models + Sankey rendering), security regressions (XSS / CSP / CORS / secret hygiene), test coverage for new branches.
- **Skip**: style nits already enforced by `ruff`/`mypy`, hypothetical generality (this is a single-deployment project).
- **Verdict line**: "Ready" / "Address findings then merge" / "Needs rework" so a glance tells you whether to look.

## Manual steps required after this PR merges

These three are out-of-band because they involve external accounts/secrets:

### 1. Install the Claude GitHub App on `cntanos/greektax`

Easiest path: from a local terminal with Claude Code installed:

```bash
/install-github-app
```

This walks you through creating/installing the GitHub App for this repo. Manual path: visit https://github.com/apps/claude and click Install.

### 2. Add the `ANTHROPIC_API_KEY` repository secret

GitHub → Settings → Secrets and variables → Actions → New repository secret.

- Name: `ANTHROPIC_API_KEY`
- Value: an API key from https://console.anthropic.com/settings/keys (use a key dedicated to this repo so you can rotate or revoke without touching others).

The workflow references `${{ secrets.ANTHROPIC_API_KEY }}`; without this secret the action exits cleanly with an error rather than reviewing without auth.

### 3. Disable the OpenAI Codex reviewer (optional but recommended)

Currently `chatgpt-codex-connector[bot]` posts a review on every PR (confirmed on #235 and #241). To avoid running both reviewers in parallel:

Visit https://chatgpt.com/codex/cloud/settings/general → find `cntanos/greektax` in the connected repositories list → toggle "Review pull requests" off.

You can leave it enabled if you want side-by-side comparison for a few PRs before fully switching.

## Cost note

The action calls the Anthropic API on every non-draft PR open and on every push to an existing PR. A typical review on a ~150-line diff runs around 50–100k input tokens + ~3k output tokens. Cost depends on which model the action defaults to (currently Sonnet 4.x); see https://www.anthropic.com/pricing for current numbers. If costs become a concern, narrow the trigger to `opened` only (drop `synchronize`) or scope by path filter.

## Verification

- [x] Workflow YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Permissions are minimum-scope (no `actions: write`, no `id-token`, etc.)
- [x] Concurrency group keyed on PR number — multiple rapid pushes won't pile up parallel reviews
- [x] Pinned by major version `@v1` (Dependabot can suggest upgrades; manual major bumps stay opt-in)
- [ ] After merge + manual setup steps: open a no-op PR (e.g. a comment change in a docs file) and verify the workflow posts a Claude review within ~2 minutes
- [ ] Verify the review's verdict line follows the prompt template

## Follow-ups (not in this PR)

- **SHA-pin the action** the same way #237 pinned `appleboy/ssh-action`. Doing it now would require a SHA lookup against `anthropics/claude-code-action`; happy to follow up.
- **Path-filtered review configurations** — e.g. lighter review for translation-only PRs, heavier review for changes under `src/greektax/backend/app/models/`. Worth adding if you find the default prompt over- or under-shooting.
