### PR TITLE
Use Claude.ai Max OAuth token instead of API key for PR review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,9 @@ name: Claude PR Review
 #
 # Setup requirements (see PR description):
 #   1. Install the Claude GitHub App on this repository.
-#   2. Add an `ANTHROPIC_API_KEY` repository secret.
+#   2. Mint a CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token` locally) so the
+#      action runs against your Claude.ai Max subscription quota instead of
+#      pay-as-you-go API billing. Add it as a repository secret.
 #   3. (Optional) Disable the previous AI reviewer (OpenAI Codex) at
 #      https://chatgpt.com/codex/cloud/settings/general.
 
@@ -37,9 +39,8 @@ jobs:
 
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are reviewing a pull request against the GreekTax repository
             (a Greek tax calculator: Python/Flask backend + static JS


### PR DESCRIPTION
## Summary

Follow-up to **PR #243**. After we settled on the workflow design and merged #243, you confirmed you have a Claude.ai **Max** subscription and want reviews to consume that quota rather than a separate Anthropic Console pay-as-you-go balance. This PR is the one-line switch.

### What changed

```diff
- env:
-   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
  with:
+   claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    prompt: |
      ...
```

The action exposes two auth inputs: `anthropic_api_key` (Console billing) and `claude_code_oauth_token` (Pro/Max subscription quota). We now use the latter. Confirmed from the action's `action.yml`:

> **claude_code_oauth_token** — Claude Code OAuth token (alternative to anthropic_api_key)

The comment block at the top of the workflow file is updated to describe the new manual steps too.

### Three manual steps now

1. **Install the Claude GitHub App on `cntanos/greektax`** (if not already done while setting up #243).
   https://github.com/apps/claude → Install → choose `cntanos/greektax`.

2. **Mint an OAuth token from your Max subscription.** From a local terminal where Claude Code is signed in to your Max account:

   ```bash
   claude setup-token
   ```

   This opens a browser, authenticates against `claude.ai`, and prints a token to the terminal. Copy it.

3. **Add the token as a repository secret.**
   GitHub → Settings → Secrets and variables → Actions → New repository secret
   - Name: `CLAUDE_CODE_OAUTH_TOKEN` (exact match — the workflow references this name)
   - Value: the token from step 2

4. **(Optional, recommended)** Disable Codex at https://chatgpt.com/codex/cloud/settings/general → toggle off for `cntanos/greektax`. You can run both in parallel for a PR or two first if you want a side-by-side.

### About the IDE warning

VS Code's GitHub Actions extension flags `secrets.CLAUDE_CODE_OAUTH_TOKEN` as "Context access might be invalid" — that's just static analysis noticing the secret isn't yet defined on the repo. The warning will disappear once step 3 above is done. (Same warning fired for `ANTHROPIC_API_KEY` in #243 before you'd added it.)

### Cost / quota note

- Pro/Max OAuth quota is per-day, shared across all your Claude usage (Claude Code, claude.ai, this action).
- Max plans have substantially higher quota than Pro. A typical 150-line PR review uses ~50-100k input tokens — well under daily limits on Max.
- If you ever push many PRs in rapid succession and hit the quota cap, the action will fail for the day; reviews resume the next quota window. No surprise billing.

### Verification

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] `action.yml` confirms `claude_code_oauth_token` is the right input name
- [ ] After merge + manual setup: open a tiny no-op PR and confirm a Claude review comment appears within ~2 minutes

### Note about merge order

PR #243 is already merged with the API-key form. If you don't merge this PR, the workflow will look for `ANTHROPIC_API_KEY` — which means you'd need to set up Console billing instead. Merging this PR before completing the manual setup is harmless: the workflow will simply fail-noop until the new secret is added.
