### PR TITLE
Smoke test: Claude PR review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ python scripts/validate_config.py
 - Dependency metadata is managed in `pyproject.toml`. Regenerate derived requirements files with `python scripts/sync_requirements.py`.
 - If UI translation strings change, run `python scripts/embed_translations.py` and commit the generated bundle.
 - Keep README updates minimal: point to canonical docs instead of duplicating procedures.
+- Pull requests get an automated review from Claude (see [`.github/workflows/claude-code-review.yml`](.github/workflows/claude-code-review.yml)).


### PR DESCRIPTION
## Summary

End-to-end smoke test of the Claude PR review workflow (`.github/workflows/claude-code-review.yml`) introduced by #243 and pivoted to the Max OAuth token in #244.

## Expected outcome

Within ~1-3 minutes of this PR opening, **Claude should post a review comment** on this PR. The comment should:

- Start with a 1-2 sentence summary describing the one-line README addition.
- List few or no findings (this is a trivial doc tweak).
- End with a verdict line: "Ready", "Address findings then merge", or "Needs rework".

## What this PR actually changes

One line added to `README.md` under "Notes for contributors" telling future contributors that PRs receive an automated Claude review. So the change is both:

- A legitimate small docs improvement.
- The smallest possible signal for the workflow to chew on.

## What to do after the review appears

- **Review appears, verdict reasonable**: merge this PR. The Claude workflow is live.
- **Review does NOT appear within 3-5 minutes**: head to https://github.com/cntanos/greektax/actions and look for the "Claude PR Review" run. Click in; logs will say why it skipped or failed (most common: secret name typo, token invalid, daily quota hit). Paste the error and I'll diagnose.
- **Review appears but is bad**: tell me what's off and I can tighten the prompt.

## Cleanup

Either merge or close — the README line is harmless either way.
