### PR TITLE
Grant id-token: write and bump actions/checkout to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  # OIDC token used by the action for the GitHub-side commenting flow.
+  id-token: write
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -32,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history so Claude can inspect base...head diffs accurately.
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Fixes the two issues PR #245's smoke test surfaced on the newly-merged Claude review workflow:

```
Error: Could not fetch an OIDC token. Did you remember to add
       `id-token: write` to your workflow permissions?

Warning: Node.js 20 actions are deprecated ... actions/checkout@v4 ...
         forced to run with Node.js 24 by default starting June 2nd, 2026.
```

Two-line workflow change:

```diff
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
```

```diff
-  uses: actions/checkout@v4
+  uses: actions/checkout@v6
```

## Why both at once

These are the only blockers to a working review pipeline. Bundling them keeps the audit trail simple.

- **`id-token: write`** — `anthropics/claude-code-action@v1` uses OIDC for the GitHub-side commenting flow even when authenticated to Claude via the OAuth token. Without this permission the action exits with the exact "Could not fetch an OIDC token" message we saw.
- **`actions/checkout@v6`** — current major (released Jan 2026), Node 24 compatible. `@v4` ships on Node 20 which GitHub force-upgrades on June 2, 2026. Bumping now avoids that scheduled break.

## Verification plan

This PR is itself the test: opening it triggers the workflow against the head-of-branch (i.e. fixed) version of the YAML.

- [ ] Within ~2 minutes of this PR opening, the "Claude PR Review" run should turn green and post a review comment.
- [ ] If it fails again, the next error message tells us what's left.

## Coupling

- Independent of any other open PR.
- After this merges, PR #245's workflow will still need a re-run (push an empty commit, or close-and-reopen) to pick up the fixed YAML, because `pull_request` events use the workflow file from the PR's head.

## What to do with PR #245

Easiest path: merge this PR, then push an empty commit to `test/claude-review-smoke` (or just close PR #245 — the README change inside it is harmless and can ship anytime).
