### PR TITLE
Smoke test #2: Claude PR review after #246 permissions fix

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,3 +43,13 @@ Place contributor-facing references in `docs/`:
 
 If a file is an example/template, label it clearly in the filename or heading
 (e.g. `*.example.*`) and explain where it is used.
+
+## Pull Request Review
+
+Every pull request opened against `main` receives an automated review from
+Claude via the `Claude PR Review` workflow at
+[`.github/workflows/claude-code-review.yml`](../.github/workflows/claude-code-review.yml).
+The review comment appears within ~2 minutes of opening or pushing to a PR and
+ends with a verdict line (`Ready`, `Address findings then merge`, or
+`Needs rework`). Use it as a sanity check rather than a gate — the human
+reviewer remains the deciding voice.


### PR DESCRIPTION
## Summary

Fresh end-to-end smoke test for the Claude PR review workflow now that #246 has merged (added `id-token: write` permission and bumped `actions/checkout` to v6). Unlike PR #245, this PR does not touch any file under `.github/workflows/`, so the action's anti-tampering guard should not block it.

## What this PR changes

One small section appended to `docs/contributing.md` documenting the automated PR review setup — both useful documentation and a minimal signal for the workflow to chew on.

## Expected outcome

Within ~1-3 minutes of opening:

1. A workflow run titled "Claude PR Review" appears at https://github.com/cntanos/greektax/actions/workflows/claude-code-review.yml referencing this PR.
2. The run completes green.
3. Claude posts a review comment on this PR with the verdict line at the bottom (`Ready`, `Address findings then merge`, or `Needs rework`).

## If it fails

Open the Actions run and look at the failing step's last few log lines. Most likely candidates given what we've already fixed:

- `401`/`Invalid token` — `claude setup-token` produced a token that's expired or got mangled when pasted. Re-run setup-token, re-paste the secret.
- `429`/`quota exceeded` — daily Max quota hit. Try again tomorrow.
- Anything else — paste the error in this thread.

## Cleanup

Once the review lands and looks reasonable, merge this PR (the docs paragraph is worth keeping) or close it — both prove the workflow works.
