### PR TITLE
Improve Claude PR review: CLAUDE.md + Opus 4.7 + SHA-pin + full output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,35 +40,22 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8  # v1 (2026-05-12)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use Opus 4.7 instead of the action's default Sonnet 4.6 — stronger
+          # reasoning on regression-prone areas like the Pydantic models and
+          # the Sankey rendering path. Cost is charged to Max quota only.
+          claude_args: --model claude-opus-4-7
+          # Surface Claude's reasoning in the workflow log so we can diagnose
+          # quality issues without re-running.
+          show_full_output: true
           prompt: |
-            You are reviewing a pull request against the GreekTax repository
-            (a Greek tax calculator: Python/Flask backend + static JS
-            frontend, no auth, no PII storage, no DB). Be terse and
-            actionable.
-
-            Focus on:
-            - Correctness of the changed logic, especially edge cases around
-              the Pydantic models in src/greektax/backend/app/models/ and the
-              Sankey/distribution rendering path in
-              src/frontend/assets/scripts/ui/app.js.
-            - Security: input validation on API routes, XSS surfaces in JS
-              (textContent vs innerHTML), localStorage usage, CSP/CORS
-              regressions, secret hygiene in workflows.
-            - Test coverage for new branches.
-            - Adherence to the existing patterns (see docs/architecture.md
-              and CLAUDE.md) — avoid suggesting refactors outside the PR's
-              scope.
-
-            Skip:
-            - Style nits already enforced by ruff/mypy.
-            - Hypothetical generality. This is a single-deployment project.
-
-            Format the review as:
-            - A 1-2 sentence summary of what the PR does.
-            - A bulleted list of findings, each tagged [bug] / [security]
-              / [perf] / [test] / [nit]. Cite file:line for each.
-            - Final verdict: "Ready", "Address findings then merge", or
-              "Needs rework".
+            Review this pull request against the GreekTax repository
+            following the conventions and priorities documented in
+            `CLAUDE.md` (loaded automatically by the action from the
+            base branch). Be terse and actionable. File inline review
+            comments anchored to specific file:line locations using
+            the tag scheme described there ([bug] / [security] /
+            [perf] / [test] / [nit]). File no comments if nothing in
+            the diff warrants one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# GreekTax review guidelines
+
+GreekTax is a Greek tax calculator. The backend is a Python/Flask app
+in `src/greektax/backend/`; the frontend is a static JS bundle in
+`src/frontend/`. There is no auth, no PII storage, no database. The
+single production deployment is `cognisys.gr` (frontend, served via
+cPanel) → `cntanos.pythonanywhere.com` (backend, hosted on
+PythonAnywhere).
+
+This file is loaded at the start of every PR review. Use it to
+prioritise findings.
+
+## What to focus on
+
+### Correctness
+
+- Pydantic models in `src/greektax/backend/app/models/` reject extra
+  fields by convention (`model_config = ConfigDict(extra="forbid")`).
+  New optional fields must default cleanly; new required fields are a
+  breaking API change worth calling out.
+- `src/frontend/assets/scripts/ui/app.js` is a ~5800-line module.
+  Every identifier it references must be declared, imported, or a
+  browser/standard global. The refactor in PR #221 dropped eleven
+  declarations that surfaced as runtime `ReferenceError`s only after
+  deployment. Flag any new bare-identifier reference (read, write,
+  update, member access) that lacks a declaration.
+- Tax brackets and rate tables live in
+  `src/greektax/backend/config/data/*.yaml`. Changes there must come
+  with a `python scripts/validate_config.py` check; flag PRs that
+  modify a year file without mentioning it.
+
+### Security
+
+- Backend response headers are set by an `after_request` hook in
+  `src/greektax/backend/app/__init__.py` (see PR #236). New endpoints
+  must not bypass it.
+- `MAX_CONTENT_LENGTH` defaults to 64 KiB. Endpoints accepting larger
+  payloads must justify the bump.
+- CORS is allow-listed via the `GREEKTAX_ALLOWED_ORIGINS` env var.
+  Cross-origin fetch surfaces also need a matching `connect-src` entry
+  in the CSP meta tag in `src/frontend/index.html` (see PR #238).
+- localStorage persistence is **opt-in** (PR #241). Form fields that
+  need to skip persistence must carry `data-no-persist`. Persisting
+  financial data without honouring `calculatorPersistenceOptIn` is a
+  regression.
+- XSS: API/user content reaches the DOM via `textContent`.
+  `innerHTML` is reserved for static-template clearing. Any new
+  `innerHTML = <interpolated>` is a bug — call it out.
+- Workflows pin third-party actions by SHA (see `appleboy/ssh-action`
+  in `.github/workflows/deploy-backend.yml`, PR #237). New uses of
+  unpinned tags are a security finding.
+
+### Tests
+
+- Frontend tests: `tests/frontend/*.test.js`, run via
+  `node --test tests/frontend`. JSDOM-dependent tests skip gracefully
+  when jsdom is not installed.
+- Backend tests: `tests/{unit,integration,e2e}/`, run via `pytest`.
+- `tests/frontend/fileSizeGuardrails.test.js` caps
+  `src/frontend/assets/scripts/ui/app.js` at 5900 lines. If a change
+  pushes it over, either trim or justify a budget bump in the PR.
+- New conditional branches in either codebase should arrive with a
+  matching test case. Coverage gaps in changed code are worth flagging.
+
+## What to skip
+
+- Style nits already enforced by `ruff` (lint/format) and `mypy`
+  (typing). The CI workflow runs both; spending review effort on
+  selectors they already cover is noise.
+- Hypothetical generality. This is a single-deployment project;
+  suggestions framed as "what if someone forks this for a different
+  backend" are not actionable. Frame findings in terms of the existing
+  deployment.
+- Translation phrasing. Both EL and EN translations are maintained by
+  the project owner; flag *missing keys* or `t(key)` calls that
+  resolve to a literal key (a deployment cache issue we've hit before
+  — see PR #242), not wording choices.
+
+## Conventions worth knowing
+
+- Translation files: `src/greektax/translations/{en,el}.json`. After
+  edits, run `python scripts/embed_translations.py` to regenerate
+  `src/frontend/assets/scripts/translations.generated.js`; otherwise
+  the deployed UI shows literal keys.
+- Deployed-static-asset cache busting: `scripts/configure_frontend.py`
+  appends `?v=<hash>` to every relative JS import and every
+  `<script src="./assets/scripts/*.js">` tag at deploy time (PR #242).
+  New `<script>` tags or new module imports that bypass this mechanism
+  will hit stale caches.
+- Pre-existing test failures: `tests/e2e/test_smoke_flow.py` asserts
+  `id="api-connection-status"` which doesn't exist in the served HTML.
+  Tracked separately; don't flag.
+
+## Output format
+
+Use inline review comments anchored to specific file:line locations.
+Inline comments are the only mechanism the current workflow uses to
+surface findings — there is no top-level summary review. Each comment
+should be 1-3 sentences and prefixed with a tag in brackets:
+
+- `[bug]` — incorrect behaviour or regression
+- `[security]` — security-relevant change worth attention
+- `[perf]` — performance concern with measurable impact
+- `[test]` — missing or weak test coverage
+- `[nit]` — minor suggestion, use sparingly
+
+If nothing in the diff warrants a comment, file none. Silence is an
+acceptable signal.


### PR DESCRIPTION
## Summary

PR #247 confirmed the Claude review workflow runs end-to-end, but the review itself was empty: Sonnet 4.6 on a 10-line docs diff with no project-specific context decided nothing was worth flagging. Three changes to make the next review meaningful.

### 1. `CLAUDE.md` at repo root

The action restores `CLAUDE.md` from the base branch before each run — this is visible in the workflow log:

```
Restoring .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc,
CLAUDE.md, CLAUDE.local.md, .husky from origin/main (PR head is untrusted)
```

So whatever the file says becomes durable per-PR project knowledge. The file is ~110 lines and codifies the actual patterns we've established across the recent PRs:

- Threat model (no auth/PII, single deployment).
- Regression patterns to watch for (PR #221's lost declarations, opt-in localStorage, the `<script src=>` cache-bust contract, ruff-already-covers-style).
- Backend security baseline (`after_request` headers, `MAX_CONTENT_LENGTH`, CORS ↔ CSP coupling).
- Test layout and the file-size guardrail.
- Comment format and tag scheme (`[bug]` / `[security]` / `[perf]` / `[test]` / `[nit]`).
- Conventions worth knowing (translations regen step, cache-bust script).
- Pre-existing test failures Claude should NOT re-flag.

### 2. Model upgraded Sonnet 4.6 → Opus 4.7

Set via the `claude_args: --model claude-opus-4-7` passthrough (the action doesn't expose a top-level `model` input — verified by inspecting the action's `action.yml`). Cost is charged against your Max OAuth quota only.

### 3. `show_full_output: true`

The previous run log redacted Claude's reasoning ("hidden for security"). Now the workflow log captures the full transcript so review-quality issues can be debugged without rerunning.

### Housekeeping bundled in

- `anthropics/claude-code-action` pinned by SHA (`f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8`, v1 as of 2026-05-12) instead of the mutable `@v1` tag — matches the pattern set by `appleboy/ssh-action` in #237. Trailing `# v1 (2026-05-12)` comment keeps the human-readable version visible.
- Inline `prompt` shrunk to defer to `CLAUDE.md` rather than duplicating its guidance.

## Verification

- [x] `python -c "import yaml; yaml.safe_load(...)"` clean
- [x] All action inputs verified against the live `action.yml` (no more invalid-input warnings)
- [x] SHA confirmed via `gh api repos/anthropics/claude-code-action/commits/v1`
- [ ] After merge: open a small non-trivial PR (something touching either `src/greektax/backend/app/` or `src/frontend/assets/scripts/ui/`) and verify Claude posts inline comments with the tag scheme. Trivial / docs-only PRs may still receive zero comments — that's working as intended.

## Coupling

Independent of any open PR. Once merged, takes effect on the next PR opened or pushed to.

## Follow-up — summary mode (not in this PR)

The action only posts inline comments tied to specific lines. There's no top-level review summary today, which is why the "verdict line" prompt I wrote earlier was inert. A second PR will wire that up via a different invocation path. Tracked separately.
