### PR TITLE
Wire summary-mode posting + sticky-comment for Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,16 +46,45 @@ jobs:
           # Use Opus 4.7 instead of the action's default Sonnet 4.6 — stronger
           # reasoning on regression-prone areas like the Pydantic models and
           # the Sankey rendering path. Cost is charged to Max quota only.
-          claude_args: --model claude-opus-4-7
+          # Allow the two posting paths: `gh pr comment` for the top-level
+          # summary and the inline-comment MCP tool for line-specific findings.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          # Collapse Claude's output into a single sticky comment that gets
+          # updated on each push instead of stacking a new comment per push.
+          use_sticky_comment: true
           # Surface Claude's reasoning in the workflow log so we can diagnose
           # quality issues without re-running.
           show_full_output: true
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request against the GreekTax repository
             following the conventions and priorities documented in
-            `CLAUDE.md` (loaded automatically by the action from the
-            base branch). Be terse and actionable. File inline review
-            comments anchored to specific file:line locations using
-            the tag scheme described there ([bug] / [security] /
-            [perf] / [test] / [nit]). File no comments if nothing in
-            the diff warrants one.
+            `CLAUDE.md` (loaded automatically from the base branch).
+            Be terse and actionable.
+
+            Post your output in two channels:
+
+            1. A SINGLE top-level summary via `gh pr comment` with this
+               structure:
+                 - One short paragraph describing what the PR does.
+                 - A short bulleted list of the most material findings
+                   (omit if there are none) tagged with [bug] /
+                   [security] / [perf] / [test] / [nit].
+                 - A final line beginning with `Verdict:` followed by
+                   one of "Ready", "Address findings then merge", or
+                   "Needs rework".
+
+            2. (Optional) Inline review comments anchored to specific
+               file:line locations via
+               `mcp__github_inline_comment__create_inline_comment` with
+               `confirmed: true`. Use these only when a finding is
+               anchored to a specific line and the reader benefits
+               from seeing it in context. Otherwise rely on the
+               summary.
+
+            Do NOT emit review text as raw model output — only post
+            it through the two channels above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,26 @@ prioritise findings.
 
 ## Output format
 
-Use inline review comments anchored to specific file:line locations.
-Inline comments are the only mechanism the current workflow uses to
-surface findings — there is no top-level summary review. Each comment
-should be 1-3 sentences and prefixed with a tag in brackets:
+Two channels:
+
+1. **One top-level summary comment** posted via `gh pr comment`. Use
+   this for the holistic read of the PR — what it does, the main
+   findings, and a verdict. Format:
+
+   - One short paragraph describing what the PR does.
+   - A short bulleted list of material findings, each prefixed with
+     `[bug]` / `[security]` / `[perf]` / `[test]` / `[nit]`. Omit
+     the list if there are no findings worth surfacing.
+   - A final line beginning with `Verdict:` followed by one of
+     "Ready", "Address findings then merge", or "Needs rework".
+
+2. **Inline review comments** anchored to specific file:line locations
+   via `mcp__github_inline_comment__create_inline_comment` (with
+   `confirmed: true`). Use these only when a finding is genuinely
+   anchored to one location and reading it in context helps. Keep
+   each one 1-3 sentences with the same tag prefix.
+
+Tag legend:
 
 - `[bug]` — incorrect behaviour or regression
 - `[security]` — security-relevant change worth attention
@@ -104,5 +120,7 @@ should be 1-3 sentences and prefixed with a tag in brackets:
 - `[test]` — missing or weak test coverage
 - `[nit]` — minor suggestion, use sparingly
 
-If nothing in the diff warrants a comment, file none. Silence is an
-acceptable signal.
+If nothing in the diff warrants attention, post a summary that says
+so (one paragraph + `Verdict: Ready`) and skip the inline channel.
+Silence on both channels is also acceptable, but a one-line "Ready"
+is clearer for the reader.


### PR DESCRIPTION
## Summary

Follows **#248**. PR #247 exposed that the action's default posting flow only buffers inline comments tied to specific lines — so on a docs-only PR with nothing to anchor a finding to, Claude runs successfully and posts nothing. This PR makes the workflow always emit a top-level summary (with the verdict line we originally specified) and treats inline comments as an optional second channel.

## Base note

This PR is targeted at the `claude/review-quality-pass-1` branch (PR #248), not directly at `main`. After #248 merges, GitHub will auto-retarget this to `main`; or you can rebase manually. Stacking this way avoids a merge conflict on the workflow file.

## What changes

### `.github/workflows/claude-code-review.yml`

1. **`claude_args`** now includes an `--allowedTools` list so Claude can actually post:

   ```yaml
   claude_args: |
     --model claude-opus-4-7
     --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
   ```

   Without those entries Claude would refuse to invoke `gh pr comment` (the summary channel) or the inline-comment MCP tool (the line-anchored channel).

2. **`use_sticky_comment: true`** — collapses Claude's output into a single comment that's edited in place on subsequent pushes, instead of stacking a fresh comment per push. Confirmed against the action's `action.yml`:

   > **use_sticky_comment** — Use just one comment to deliver issue/PR comments

3. **Prompt rewritten** to spell out the two-channel contract explicitly: one summary via `gh pr comment` (paragraph + findings + `Verdict:` line), zero-or-more inline comments via the MCP tool. The prompt also frames it as "do not emit review text as raw model output" so Claude doesn't get tempted to dump the review into the action's own log without ever posting it.

### `CLAUDE.md`

The "Output format" section is rewritten in lockstep so the two sources of truth agree. Now describes two channels (summary + inline) with the same tag scheme, and tells Claude that a one-paragraph "everything looks fine, `Verdict: Ready`" summary is preferred over silence even on trivial PRs.

## Verification

- [x] `python -c "import yaml; yaml.safe_load(...)"` clean
- [x] Tool names cross-checked against the action's docs/solutions.md example
- [x] Action input names verified against the action's live `action.yml`
- [ ] After merge: open a fresh test PR (any small change to a docs file is enough). Expect a single top-level summary comment authored by `claude[bot]` with a `Verdict:` line at the end. On a subsequent push to the same PR, the comment is **edited in place** rather than duplicated.

## Reference

The pattern is taken from the action's own `docs/solutions.md`, which documents the same `--allowedTools` + dual-channel approach for review use cases.
